### PR TITLE
i168 - Corrige sliders, texto en inglés en select de Buscar Voluntario de evaluaciones

### DIFF
--- a/app/Http/Controllers/ajax/UsuarioController.php
+++ b/app/Http/Controllers/ajax/UsuarioController.php
@@ -189,8 +189,8 @@ class UsuarioController extends BaseController
         }
 
         // ofuscar en tabla persona
-        $persona->nombres = str_random(30);
-        $persona->apellidoPaterno = str_random(30);
+        $persona->nombres = 'Usuario Anónimo';
+        $persona->apellidoPaterno = '';
         $persona->telefono = str_random(30);
         $persona->telefonoMovil = str_random(30);
         $persona->dni = str_random(8);

--- a/resources/assets/js/components/evaluaciones/contenedorEvaluaciones.vue
+++ b/resources/assets/js/components/evaluaciones/contenedorEvaluaciones.vue
@@ -26,6 +26,7 @@
                             v-model="personaSeleccionada"
                             :filterable=true
                     >
+                        <span slot="no-options">Empezá a escribir para buscar.</span>
                     </v-select>
                 </div>
             </div>

--- a/resources/assets/js/components/evaluaciones/evaluarActividad.vue
+++ b/resources/assets/js/components/evaluaciones/evaluarActividad.vue
@@ -34,7 +34,7 @@
                                            min="1"
                                            max="10"
                                            step="1"
-                                           :disabled="evaluacionPasada || enviado"
+                                           :disabled="noAplica || evaluacionPasada || enviado"
                                            v-model="puntaje">
                                 </div>
 


### PR DESCRIPTION
## Descripción

- Corrige nombre anónimo al eliminar una cuenta
- Corrige funcionalidad de Sliders en mobile y escritorio
- Corrige grisado de campos cuando corresponde
- Corrige texto en inglés al desplegar el select de buscar voluntario en página de evaluaciones (front end).

Si arregla un defecto o incorpora una funcionalidad poné el link al issue:

Forma parte de las correcciones del issue #168 

## ¿Cómo testeaste?

- [ ] Acceder a las evaluaciones de una actividad, intentar buscar un voluntario. Verificar el texto que aparece antes de escribir.
- [ ] Eliminar un usuario que sea usado en una evaluación. Al ingresar con otro usuario que participaba de la misma actividad del usuario eliminado, que la caja de evaluación tenga en el título "Usuario Anónimo".
- [ ] Revisar que al seleccionar el checkbox "No Aplica", su slider/barra de puntaje relacioanada, se deshabilite.
- [ ] Revisar que cuando se envía una evaluación, todos los campos se deshabiliten.
- [ ] Revisar que cuando las fechas de evaluación pasaron, no queden campos habilitados.

## Checklist:

- [x] Revisé mi código
