### PR TITLE
i183 - fix link volver en proceso de pago

### DIFF
--- a/resources/views/actividades/show.blade.php
+++ b/resources/views/actividades/show.blade.php
@@ -111,37 +111,6 @@
 @endsection
 
 @section('footer')
-{{--<footer class="row fixed-bottom align-middle inscripcion-bar">--}}
-{{--
-    <div class="container">
-        <div class="col-md-7">
-            <h5>{{ $actividad->nombreActividad }}</h5>
-        </div>
-        <div class="col-md-2">
-            <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#compartirModal">
-                <i class="fas fa-share-alt"></i>  COMPARTIR
-            </button>
-        </div>
-        @if (Auth::check() && Auth::user()->estaInscripto($actividad->idActividad))
-            <div class="col-md-3"><span class="btn btn-success w-100">YA TE INSCRIBISTE!</span></div>
-        @elseif($hayCupos && $inscripcionAbierta)
-            <div class="col-md-3">
-                <a class="btn btn-primary inscripcion-btn w-100"
-                   href="/inscripciones/actividad/{{$actividad->idActividad}}">
-                    INSCRIBIRME
-                </a>
-            </div>
-        @else
-            <div class="col-md-3">
-            <span class="btn btn-danger inscripcion-btn w-100">
-                INSCRIPCIÓN CERRADA
-            </span>
-            </div>
-        @endif
-    </div>
-</footer>
---}}
-
 <footer class="footer inscripcion-bar fixed-bottom">
     <div class="container">
         <div class="row">

--- a/resources/views/inscripciones/pagar-paso-1.blade.php
+++ b/resources/views/inscripciones/pagar-paso-1.blade.php
@@ -94,7 +94,11 @@
                             <div class="col-md-4">
                                 <br><br>
                                 <p>
-                                    <a href="{{ url()->previous() }}" class="btn btn-link">VOLVER</a>
+                                    @if(Auth::check() && Auth::user()->estaPreInscripto($actividad->idActividad))
+                                        <a href="{{ action('ActividadesController@show', ['id' => $actividad->idActividad]) }}" class="btn btn-link">VOLVER</a>
+                                    @else
+                                        <a href="{{ action('InscripcionesController@puntoDeEncuentro', ['id' => $actividad->idActividad]) }}" class="btn btn-link">VOLVER</a>
+                                    @endif
                                 </p>
                             </div>
                         </div>

--- a/resources/views/inscripciones/pagar-paso-2.blade.php
+++ b/resources/views/inscripciones/pagar-paso-2.blade.php
@@ -67,7 +67,7 @@
                     <div class="col-md-4">
                         <br><br>
                         <p>
-                            <a href="{{ url()->previous() }}" class="btn btn-link">VOLVER</a>
+                            <a href="{{ action('InscripcionesController@confirmarDonacion', ['id' => $actividad->idActividad]) }}" class="btn btn-link">VOLVER</a>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
## Descripción

Corrige un error que aparecía a veces al clickear en el link "Volver" en el paso 1 y/o paso 2 del proceso de pago.

Si arregla un defecto o incorpora una funcionalidad poné el link al issue:

Arregla #183 

## ¿Cómo testeaste?

- [ ] Inscribirse a una actividad de pago. Llegar al paso de ingresar un monto. Hacer clic en volver. Repetir el proceso llegando al paso 2. En lugar de hacer clic en el botón que lleva a la plataforma de pago, hacer clic en Volver.
- [ ] Repetir el proceso del test anterior, pero partiendo desde una pre-inscripción. (Ingresar a actividad pre-inscripta).


## Checklist:

- [x] Revisé mi código
