### PR TITLE
i179 - Fix visualizacion de formulario de usuario en backoffice (mobile)

### DIFF
--- a/resources/assets/js/components/backoffice/usuarios/usuario-form.vue
+++ b/resources/assets/js/components/backoffice/usuarios/usuario-form.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="usuario-component">
         <div v-show="guardado" class="callout callout-success">
             <h4>{{ mensajeGuardado }}</h4>
         </div>
@@ -371,5 +371,9 @@
 </script>
 
 <style scoped>
-
+    @media (max-width: 768px) {
+        .usuario-component {
+            margin-bottom: 120px;
+        }
+    }
 </style>


### PR DESCRIPTION
## Descripción

Corrige un problema de CSS que impedía ver el final del formulario de usuario en el backoffice cuando se accedía desde un dispositivo mobile.

Si arregla un defecto o incorpora una funcionalidad poné el link al issue:

Arregla #179 

## ¿Cómo testeaste?

- [ ] Acceder desde un celular al panel de administración. Ir a opción Usuarios -> Registrar Usuario. Ver el final del formulario. Deberían verse los campos Provincia y Localidad.
- [ ] Acceder desde un celular al panel de administración. Ir a opción Usuarios -> Ver listado  -> seleccionar un usuario. Al visualizar el formulario, se deberían ver los campos de Provincia y Localidad.


## Checklist:

- [x] Revisé mi código
