### PR TITLE
I212 - Fix issue con imagenes en mails

### DIFF
--- a/resources/views/emails/confimacionInscripcion.blade.php
+++ b/resources/views/emails/confimacionInscripcion.blade.php
@@ -94,7 +94,7 @@
                 {{$inscripcion->punto_encuentro->responsable->nombres}}
                 {{$inscripcion->punto_encuentro->responsable->apellidoPaterno}}
                 <a href="mailto:{{ $inscripcion->punto_encuentro->responsable->mail }}" target="_blank">
-                    {{ $inscripcion->actividad->coordinador->mail }}
+                    {{ $inscripcion->actividad->responsable->mail }}
                 </a>
 
             </p>

--- a/resources/views/emails/confimacionInscripcion.blade.php
+++ b/resources/views/emails/confimacionInscripcion.blade.php
@@ -94,7 +94,7 @@
                 {{$inscripcion->punto_encuentro->responsable->nombres}}
                 {{$inscripcion->punto_encuentro->responsable->apellidoPaterno}}
                 <a href="mailto:{{ $inscripcion->punto_encuentro->responsable->mail }}" target="_blank">
-                    {{ $inscripcion->actividad->responsable->mail }}
+                    {{ $inscripcion->punto_encuentro->responsable->mail }}
                 </a>
 
             </p>

--- a/resources/views/emails/template.blade.php
+++ b/resources/views/emails/template.blade.php
@@ -33,7 +33,7 @@
                 <tr bgcolor="#0092dd">
                     <td align="left">
                         <a href="{{ url('/') }}">
-                            <img src="{{ $message->embed(url('img/techo-logo_269x83.png')) }}" alt="Techo" width="170">
+                            <img src="{{ url('img/techo-logo_269x83.png') }}" alt="Techo" width="170">
                         </a>
                         {{--@yield('header')--}}
                     </td>

--- a/resources/views/emails/template.blade.php
+++ b/resources/views/emails/template.blade.php
@@ -33,7 +33,7 @@
                 <tr bgcolor="#0092dd">
                     <td align="left">
                         <a href="{{ url('/') }}">
-                            <img src="{{ url('img/techo-logo_269x83.png') }}" alt="Techo" width="170">
+                            <img src="{{ $message->embed(url('img/techo-logo_269x83.png')) }}" alt="Techo" width="170">
                         </a>
                         {{--@yield('header')--}}
                     </td>


### PR DESCRIPTION
## Descripción

Corrige issue #212 

## ¿Cómo testeaste?

- [x] Inscribirse a una actividad con un mail válido (tener seteado la opción de recibir notificaciones). Revisar la casilla. El mail debería tener las imágenes (Logo en header, footer).
- [x] Revisar que el link de la imagen de abajo se vea correctamente. No debería decir localhost.
![imagen](https://user-images.githubusercontent.com/94343/46316009-54560780-c5a5-11e8-8b4c-9e33e2cc5541.png)

## Checklist:

- [x] Revisé mi código
