### PR TITLE
Fix error de redirección al crear actividad con usuario coordinador

### DIFF
--- a/resources/assets/js/components/backoffice/actividades/actividades-show.vue
+++ b/resources/assets/js/components/backoffice/actividades/actividades-show.vue
@@ -631,7 +631,7 @@
                 this.axiosPost(url, //endpoint
                     function (data, self) { //handler de success
                         if (self.dataActividad.idActividad === null) {
-                            window.location.replace('/admin/actividades');
+                            window.location.replace('/admin/actividades/usuario');
                         }
                         self.mensajeGuardado = data;
                         self.guardado = true;

--- a/resources/views/backoffice/actividades/show.blade.php
+++ b/resources/views/backoffice/actividades/show.blade.php
@@ -176,7 +176,7 @@
 
 @section('footer')
     <crud-footer
-            cancelar-url="/admin/actividades"
+            cancelar-url="/admin/actividades/usuario"
             edicion="{{ $edicion }}"
             compartir="{{ $compartir }}"
             can-editar="{{ Auth::user()->hasPermissionTo('editar_actividad') &&


### PR DESCRIPTION
## Descripción

Al cargar una actividad como coordinador, luego de guardar, el sistema intenta redirigir al usuario a una ruta que no tiene permisos, dando un error 403.

Arregla #222 

## ¿Cómo testeaste?

Describí que hiciste para verificar los cambios.

- [x] Loguearse con usuario con rol de coordinador. Crear Actividad. Guardar. Debería redirigir a Mis Actividades.

## Checklist:

- [x] Revisé mi código
