### PR TITLE
i224 - Corrige problema con asignación de un grupo sobre si mismo

### DIFF
--- a/app/Http/Controllers/backoffice/ajax/GruposActividadesController.php
+++ b/app/Http/Controllers/backoffice/ajax/GruposActividadesController.php
@@ -30,7 +30,7 @@ class GruposActividadesController extends BaseController
         $personaArray = [];
         try {
             foreach ($request->miembros as $item) {
-                if ($item['tipo'] === 'grupo') {
+                if ($item['tipo'] === 'grupo' && $item['id'] !== $request->idGrupoDestino) {
                     $grupoArray[] = $item['id'];
                 }
 


### PR DESCRIPTION
## Descripción

Arregla #224 

## ¿Cómo testeaste?

Describí que hiciste para verificar los cambios.

- [x] Agarrar una actividad. Agregarle algunos inscriptos, agregar un grupo. Seleccionar todos (incluído el grupo nuevo), hacer click en Asignar grupo, seleccionar el grupo nuevo. 
- [x] Acceder al grupo nuevo, ver los inscriptos. Crear otro grupo. Seleccionar todos (incluído el grupo nuevo). Hacer clic en Asignar Grupo. Asignarle el grupo raíz.

## Checklist:

- [x] Revisé mi código

