### PR TITLE
i228 - Hace opcional el campo beca en el formulario de actividad

### DIFF
--- a/app/Http/Controllers/backoffice/ActividadesController.php
+++ b/app/Http/Controllers/backoffice/ActividadesController.php
@@ -334,9 +334,11 @@ class ActividadesController extends Controller
             return isset($request['tipo']['flujo']) && $request['tipo']['flujo'] == 'CONSTRUCCION';
         });
 
-        $v->sometimes('beca', 'url', function ($request) {
-            return isset($request['tipo']['flujo']) && $request['tipo']['flujo'] == 'CONSTRUCCION';
-        });
+        if(!empty($request->beca)){
+            $v->sometimes('beca', 'url', function ($request) {
+                return isset($request['tipo']['flujo']) && $request['tipo']['flujo'] == 'CONSTRUCCION';
+            });
+        }
 
         return $v;
     }

--- a/resources/assets/js/components/backoffice/actividades/actividades-show.vue
+++ b/resources/assets/js/components/backoffice/actividades/actividades-show.vue
@@ -385,6 +385,7 @@
                                v-bind:disabled="readonly"
                                v-model="dataActividad.beca"
                         >
+                        <span class="text-muted">Opcional</span>
                     </div>
                 </div>
             </div>

--- a/resources/views/emails/confimacionInscripcion.blade.php
+++ b/resources/views/emails/confimacionInscripcion.blade.php
@@ -52,7 +52,10 @@
             los gastos de traslado, seguro y comida durante la construcción. En el caso que no puedas abonar,
             no queremos que dejes de participar, escríbenos a
             <a href="mailto:problemasdepago.argentina@techo.org" target="_blank">problemasdepago.argentina@techo.org</a>
-            para gestionar una PRÓRROGA o <a href="{{ $inscripcion->actividad->beca }}">BECA</a>.
+            para gestionar una PRÓRROGA
+            @if(!empty($inscripcion->actividad->beca))
+                o <a href="{{ $inscripcion->actividad->beca }}">BECA</a>.
+            @endif
         </p>
     @endif
 

--- a/resources/views/inscripciones/pagar-paso-1.blade.php
+++ b/resources/views/inscripciones/pagar-paso-1.blade.php
@@ -43,8 +43,13 @@
                 Para realizar tu donación
             </h3>
             <p>
+                @if(!empty($actividad->beca))
                 Vas a estar recibiendo por mail un link con instrucciones para que puedas donar con la plataforma de pagos en otro momento.
                 Si quieres, puedes realizar tu donativo con el botón de aquí abajo, o puedes solicitar una beca.
+                @else
+                    Vas a estar recibiendo por mail un link con instrucciones para que puedas donar con la plataforma de pagos en otro momento.
+                    Si quieres, puedes realizar tu donativo con el botón de aquí abajo.
+                @endif
             </p>
 
             @if($actividad->tipo->flujo == "CONSTRUCCION")
@@ -71,18 +76,20 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-md-4">
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <p class="font-weight-bold"> &nbsp;o también puedes</p>
+                            @if(!empty($actividad->beca))
+                                <div class="col-md-4">
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <p class="font-weight-bold"> &nbsp;o también puedes</p>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <a href="{{ $actividad->beca }}" class="btn btn-link" target="_blank">SOLICITAR UNA BECA</a>
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <a href="{{ $actividad->beca }}" class="btn btn-link" target="_blank">SOLICITAR UNA BECA</a>
-                                    </div>
-                                </div>
-                            </div>
+                            @endif
                         </div>
                         <br><br>
                         <div class="row">

--- a/resources/views/inscripciones/pagar-paso-2.blade.php
+++ b/resources/views/inscripciones/pagar-paso-2.blade.php
@@ -43,8 +43,13 @@
                 Para realizar tu donación
             </h3>
             <p>
-                Vas a estar recibiendo por mail un link con instrucciones para que puedas donar con la plataforma de pagos en otro momento.
-                Si quieres, puedes realizar tu donativo con el botón de aquí abajo, o puedes solicitar una beca.
+                @if(!empty($actividad->beca))
+                    Vas a estar recibiendo por mail un link con instrucciones para que puedas donar con la plataforma de pagos en otro momento.
+                    Si quieres, puedes realizar tu donativo con el botón de aquí abajo, o puedes solicitar una beca.
+                @else
+                    Vas a estar recibiendo por mail un link con instrucciones para que puedas donar con la plataforma de pagos en otro momento.
+                    Si quieres, puedes realizar tu donativo con el botón de aquí abajo.
+                @endif
             </p>
 
             @if($actividad->tipo->flujo == "CONSTRUCCION")


### PR DESCRIPTION
## Descripción

Incopora #228 

## ¿Cómo testeaste?

- [x] 1. Crear una nueva actividad construcción. Completar todos los campos normalmente. No poner nada en el campo Link del formulario de beca. Grabar. No debería solicitar completar este campo
- [x] 2. Repetir la prueba anterior o editar una actividad, completar el campo beca con un valor que no sea una URL. El sistema debe validar que el valor es incorrecto.
- [x] 3. Verificar que al inscribirse a una actividad que es de construcción pero no tiene link de beca, no figura ninguna información relacionada a una beca en las páginas de inscripción.
- [x] 4. Verificar que en el mail de inscripción no figure ningún link de beca 
- [x] 5. Crear una actividad construcción con link de beca y repetir las pruebas 3 y 4. Ahora si debería contener la información de beca.

## Checklist:

- [x] Revisé mi código

