### PR TITLE
Cuando una persona quería iniciar sesión con facebook, ya existía la …

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -139,7 +139,7 @@ class LoginController extends Controller
             $personaData->email = $user->user['email'];
             $personaData->facebook_id = $user->user['id'];
             $personaData->google_id = '';
-            
+
             if(isset($user->user['gender'])){
                 $personaData->sexo = $user->user['gender'] == 'male' ? 'M' : 'F';
             } else {
@@ -156,13 +156,15 @@ class LoginController extends Controller
                     Auth::login($persona, true);
                     $request->session()->regenerate();
                 } else {
-                    return view('registro')->with('persona', $personaData)->with('linkear',true);    
+                    return view('registro')->with('persona', $personaData)->with('linkear',true);
                 }
             }
             if($provider == 'facebook') {
                 if($persona->facebook_id == $personaData->facebook_id) {
                     Auth::login($persona, true);
                     $request->session()->regenerate();
+                } else {
+                    return view('registro')->with('persona', $personaData)->with('linkear',true);
                 }
             }
             if(Auth::check()) {


### PR DESCRIPTION
## Descripción

Corrige para que aparezca el menú "vincular cuenta facebook" al iniciar sesión por primera vez con facebook y puede iniciar sesión correctamente.

Si arregla un defecto o incorpora una funcionalidad poné el link al issue:

Fixes #239

Al importar usuarios de pilote nos dimos cuenta que fallaban los usuarios importados al intentar iniciar sesión con facebook, pero no pasaba con google. Falta una línea de código solamente.

## ¿Cómo testeaste?

Incorporé el cambio en dev, y probé en sandbox borrar el facebook_id de un usuario e iniciar sesión.
Funcionó correctamente.

## Checklist:

- [x ] Revisé mi código
