### PR TITLE
Arregla #256. Link de actividad roto en plantilla de mail, mail de pr…

### DIFF
--- a/resources/views/emails/confimacionInscripcion.blade.php
+++ b/resources/views/emails/confimacionInscripcion.blade.php
@@ -3,15 +3,39 @@
 @section('content')
 
     <p style="font-size: larger">
-        Hola {{$inscripcion->persona->nombres}},
+        Hola {{$inscripcion->persona->nombres}}
     </p>
-    <p>Te has inscripto para participar en <strong>{{$inscripcion->actividad->nombreActividad}}</strong>
-        de TECHO - {{$inscripcion->actividad->pais->nombre}} que inicia
-        el {{$inscripcion->actividad->fechaInicio->format('d/m/Y')}} en
-        <b>
-            {{$inscripcion->actividad->localidad->localidad}}, {{$inscripcion->actividad->provincia->provincia}}
-        </b>
+    <p>Te has inscripto para participar: <strong>{{$inscripcion->actividad->nombreActividad}}</strong>
+        Inicia el <strong>{{$inscripcion->actividad->fechaInicio->format('d/m/Y')}}</strong> en
+            <strong>{{$inscripcion->actividad->localidad->localidad}}, {{$inscripcion->actividad->provincia->provincia}}</strong>
     </p>
+
+    @if(strtoupper($inscripcion->actividad->tipo->flujo) == "CONSTRUCCION")
+        <p>
+            <strong>
+                <span style="color:rgb(255,153,0)">SOLO FALTA CONFIRMAR CON TU DONACIÓN</span>
+            </strong>
+        </p>
+        <p>
+            ¡Tenés tiempo hasta el <b>{{$inscripcion->actividad->fechaFinInscripciones->format('d/m/Y')}}</b>!
+        </p>
+        <p>
+            Para confirmar tu participación, haz click en el botón
+            <strong>Confirmar con tu donación</strong> en la <a href="{{ url('/inscripciones/actividad/' . $inscripcion->actividad->idActividad ) }}" >actividad.</a>
+        </p>
+        <p>
+            Te recordamos que el monto mínimo sugerido para abonar es de <b>{{ number_format($inscripcion->actividad->montoMin,0) }} {{$inscripcion->actividad->moneda}}</b>, los cuales cubren
+            los gastos de traslado, seguro y comida durante la construcción.
+        </p>
+        <p>
+            En el caso que no puedas abonar, no queremos que dejes de participar,
+            @if(!empty($inscripcion->actividad->beca))
+                solicitá una <a href="{{ $inscripcion->actividad->beca }}">BECA</a>.
+            @else
+                ponete en contacto con el coodinador de la actividad para gestionar una BECA
+            @endif
+        </p>
+    @endif
 
     @if($inscripcion->actividad->coordinador)
         <p>
@@ -26,81 +50,44 @@
     @endif
 
     <p>
+      <strong>
+          Mensaje del coordinador:
+      </strong>
         {{$inscripcion->actividad->mensajeInscripcion}}
     </p>
 
-    @if(strtoupper($inscripcion->actividad->tipo->flujo) == "CONSTRUCCION")
-        <p>
-            <strong>
-                <span style="font-size:20px">Ahora SOLO FALTA UN PASO: <br>
-                <span style="color:rgb(255,153,0)">ABONAR A LA ACTIVIDAD </span>
-                </span>
-            </strong>
-        </p>
-        <p>
-            ¡Tenes tiempo hasta el <b>{{$inscripcion->actividad->fechaFinInscripciones->format('d/m/Y')}}</b>
-            para confirmar tu inscripción!
-        </p>
-        <p>
-            Para confirmar tu participación, inicia sesión con tu cuenta y haz click en el botón
-            <strong>Confirmar con tu donación</strong> en el <a
-                    href="{{ url('/inscripciones/actividad/' . $inscripcion->actividad->idActividad . '/confirmar/donacion/') }}"
-            >detalle de la actividad.</a>
-        </p>
-        <p>
-            Te recordamos que el monto mínimo sugerido para abonar es de <b>${{$inscripcion->actividad->montoMin}}</b>, los cuales cubren
-            los gastos de traslado, seguro y comida durante la construcción. En el caso que no puedas abonar,
-            no queremos que dejes de participar, escríbenos a
-            <a href="mailto:problemasdepago.argentina@techo.org" target="_blank">problemasdepago.argentina@techo.org</a>
-            para gestionar una PRÓRROGA
-            @if(!empty($inscripcion->actividad->beca))
-                o <a href="{{ $inscripcion->actividad->beca }}">BECA</a>.
-            @endif
-        </p>
-    @endif
 
-    <p>¡Te esperamos!</p>
 
     @if($inscripcion->punto_encuentro)
         <p>
-            <strong>
-                Punto de encuentro:
-            </strong>
-        </p>
-        <p>
-            {{$inscripcion->punto_encuentro->punto}}
-            @if(!empty($inscripcion->punto_encuentro->localidad)), {{$inscripcion->punto_encuentro->localidad->localidad}}
+          <strong>
+              Punto de encuentro:
+          </strong>
+            {{$inscripcion->punto_encuentro->punto}} ({{ str_limit($inscripcion->punto_encuentro->horario, 5, '')}}hs)
+            @if(!empty($inscripcion->punto_encuentro->localidad))
+            {{$inscripcion->punto_encuentro->localidad->localidad}},
             @endif
-            @if(!empty($inscripcion->punto_encuentro->provincia))
-                ,{{$inscripcion->punto_encuentro->provincia->provincia}}
-            @endif
-            @if(!empty($inscripcion->punto_encuentro->pais))
-                ,{{$inscripcion->punto_encuentro->pais->nombre}}
-            @endif
-        </p>
-        <p>
-            <strong>
-                Horario:
-            </strong>
-        </p>
-        <p>
-            {{ str_limit($inscripcion->punto_encuentro->horario, 5, '')}}
+            {{$inscripcion->punto_encuentro->provincia->provincia}}, {{$inscripcion->punto_encuentro->pais->nombre}}
         </p>
 
         @if($inscripcion->punto_encuentro->responsable)
             <p>
                 <strong>
-                    Coordinador del punto de encuentro:
+                    Referente del punto de encuentro:
                 </strong>
             </p>
             <p>
                 {{$inscripcion->punto_encuentro->responsable->nombres}}
                 {{$inscripcion->punto_encuentro->responsable->apellidoPaterno}}
-                <a href="mailto:{{ $inscripcion->punto_encuentro->responsable->mail }}" target="_blank">
+                <p><a href="mailto:{{ $inscripcion->punto_encuentro->responsable->mail }}" target="_blank">
                     {{ $inscripcion->punto_encuentro->responsable->mail }}
-                </a>
-
+                </a></p>
+                <p>{{ $inscripcion->punto_encuentro->responsable->telefonoMovil }}</p>
             </p>
         @endif
     @endif
+
+    <p>¡Te esperamos!</p>
+    TECHO - {{$inscripcion->actividad->pais->nombre}}
+
 @endsection

--- a/resources/views/emails/template.blade.php
+++ b/resources/views/emails/template.blade.php
@@ -47,7 +47,6 @@
                             <tr>
                                 <td class="content-cell">
                                     @yield('content')
-                                    <p> ¡Muchas gracias!</p>
                                 </td>
                             </tr>
                             <tr>


### PR DESCRIPTION
## Descripción

Arregla link de actividad roto en plantilla de mail, mail de problemas de pago sacado. Además hace algunos arreglos estéticos y suma el teléfono del referente de punto.

Arregla #256 

Arreglos de disposición, palabras, tildes, etc

## ¿Cómo testeaste?

Describí que hiciste para verificar los cambios.

- [x] Hice la inscripción y recibí el mail en mailtrap
![image](https://user-images.githubusercontent.com/94343/47237923-d96b5a00-d3b6-11e8-864f-a82f6d0c171d.png)

## Checklist:

- [x] Revisé mi código
- [ ] Agregué tests que muestran que mi arreglo está bien o que mi funcionalidad anda.
