### PR TITLE
Arregla defecto #189 "Sorry, no matching options."

### DIFF
--- a/resources/assets/js/components/backoffice/actividades/actividades-show.vue
+++ b/resources/assets/js/components/backoffice/actividades/actividades-show.vue
@@ -37,7 +37,7 @@
                         <v-select
                                 :options="dataCoordinadores"
                                 label="nombre"
-                                placeholder="Escribe el nombre o apellido"
+                                placeholder="Escribe el nombre, apellido o email"
                                 name="coordinador"
                                 id="coordinador"
                                 v-model="coordinadorSeleccionado"
@@ -46,6 +46,7 @@
                                 @search="onSearch"
                                 :onChange=this.actualizarCoordinador()
                         >
+                        <span slot="no-options"></span>
                         </v-select>
                     </div>
                 </div>
@@ -88,6 +89,7 @@
                                 :filterable=false
                                 :onChange=this.getTiposDeActividad()
                         >
+                        <span slot="no-options"></span>
                         </v-select>
                     </div>
                 </div>
@@ -103,6 +105,7 @@
                                 v-model="tipoSeleccionado"
                                 v-bind:disabled="this.readonly"
                         >
+                        <span slot="no-options"></span>
                         </v-select>
                     </div>
                 </div>
@@ -214,7 +217,7 @@
                         <v-select
                                 :options="dataPaises"
                                 label="nombre"
-                                placeholder="Seleccione"
+                                placeholder="Escribe el nombre"
                                 name="pais"
                                 id="pais"
                                 v-model="paisSeleccionado"
@@ -230,13 +233,14 @@
                         <v-select
                                 :options="dataProvincias"
                                 label="provincia"
-                                placeholder="Seleccione"
+                                placeholder="Escribe el nombre"
                                 name="provincia"
                                 id="provincia"
                                 v-model="provinciaSeleccionada"
                                 v-bind:disabled="this.readonly"
                                 :onChange=this.getLocalidades()
                         >
+                        <span slot="no-options"></span>
                         </v-select>
                     </div>
                 </div>
@@ -246,13 +250,14 @@
                         <v-select
                                 :options="dataLocalidades"
                                 label="localidad"
-                                placeholder="Seleccione"
+                                placeholder="Escribe el nombre"
                                 name="localidad"
                                 id="localidad"
                                 v-model="localidadSeleccionada"
                                 v-bind:disabled="this.readonly"
                                 :onChange="this.setLocalidad()"
                         >
+                        <span slot="no-options"></span>
                         </v-select>
                     </div>
                 </div>

--- a/resources/assets/js/components/backoffice/actividades/punto-encuentro.vue
+++ b/resources/assets/js/components/backoffice/actividades/punto-encuentro.vue
@@ -37,7 +37,7 @@
                     <v-select
                             :options="dataCoordinadores"
                             label="nombre"
-                            placeholder="Escribe el nombre o apellido"
+                            placeholder="Escribe el nombre, apellido o email"
                             name="coordinador"
                             id="coordinador"
                             v-model="coordinador"
@@ -45,6 +45,7 @@
                             :filterable=false
                             @search="onSearch"
                     >
+                    <span slot="no-options"></span>
                     </v-select>
                     <p class="text-danger" v-show="errorCoordinador"><small>Este campo es requerido</small></p>
                 </div>
@@ -63,12 +64,13 @@
                     <v-select
                             :options="dataProvincias"
                             label="provincia"
-                            placeholder="Seleccione"
+                            placeholder="Escribe el nombre"
                             name="provincia"
                             id="provincia"
                             v-model="provinciaSeleccionada"
                             v-bind:disabled="this.readonly"
                     >
+                    <span slot="no-options"></span>
                     </v-select>
                     <p class="text-danger" v-show="errorProvincia"><small>Este campo es requerido</small></p>
                 </div>
@@ -79,12 +81,13 @@
                     <v-select
                             :options="dataLocalidades"
                             label="localidad"
-                            placeholder="Seleccione"
+                            placeholder="Escribe el nombre"
                             name="localidad"
                             id="localidad"
                             v-model="localidadSeleccionada"
                             v-bind:disabled="this.readonly"
                     >
+                    <span slot="no-options"></span>
                     </v-select>
                     <p class="text-danger" v-show="errorLocalidad"><small>Este campo es requerido</small></p>
                 </div>

--- a/resources/assets/js/components/backoffice/roles/asignacionDeRol.vue
+++ b/resources/assets/js/components/backoffice/roles/asignacionDeRol.vue
@@ -13,13 +13,14 @@
                                 <v-select
                                         :options="dataUsuarios"
                                         label="nombre"
-                                        placeholder="Seleccione"
+                                        placeholder="Escribe nombre, apellido o email"
                                         name="usuario"
                                         id="usuario"
                                         v-model="usuarioSeleccionado"
                                         :filterable=false
                                         @search="onSearchUsuario"
                                 >
+                                <span slot="no-options"></span>
                                 </v-select>
                             </div>
                         </div>

--- a/resources/assets/js/components/backoffice/usuarios/usuario-form.vue
+++ b/resources/assets/js/components/backoffice/usuarios/usuario-form.vue
@@ -146,13 +146,14 @@
                                     <v-select
                                             :options="dataPaises"
                                             label="nombre"
-                                            placeholder="Seleccione"
+                                            placeholder="Escribe el nombre"
                                             name="pais"
                                             id="pais"
                                             v-model="paisSeleccionado"
                                             v-bind:disabled="this.readonly"
                                             :onChange=this.getProvincias()
                                     >
+                                    <span slot="no-options"></span>
                                     </v-select>
                                 </div>
                             </div>
@@ -164,13 +165,14 @@
                                     <v-select
                                             :options="dataProvincias"
                                             label="provincia"
-                                            placeholder="Seleccione"
+                                            placeholder="Escribe el nombre"
                                             name="provincia"
                                             id="provincia"
                                             v-model="provinciaSeleccionada"
                                             v-bind:disabled="this.readonly"
                                             :onChange=this.getLocalidades()
                                     >
+                                    <span slot="no-options"></span>
                                     </v-select>
                                 </div>
                             </div>
@@ -182,12 +184,13 @@
                                     <v-select
                                             :options="dataLocalidades"
                                             label="localidad"
-                                            placeholder="Seleccione"
+                                            placeholder="Escribe el nombre"
                                             name="localidad"
                                             id="localidad"
                                             v-model="usuario.localidad"
                                             v-bind:disabled="this.readonly"
                                     >
+                                    <span slot="no-options"></span>
                                     </v-select>
                                 </div>
                             </div>


### PR DESCRIPTION
Arregla defecto #189. Error: Sorry, no matching options en el control de selección de vue en el backend

![image](https://user-images.githubusercontent.com/94343/48157721-2c964580-e2af-11e8-9d28-57bae903aadd.png)

Podría estar mejor, pero es un paliativo simple y funciona. Salió de [acá](https://github.com/sagalbot/vue-select/issues/196)

## ¿Cómo testeaste?

Describí que hiciste para verificar los cambios.

- [ ] Visualmente en el interfaz de Actividades, Roles y Usuarios en el backend


## Checklist:

- [x] Revisé mi código
