### PR TITLE
Fix: agrega un log para saber cuando se mandó mail

### DIFF
--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -30,9 +30,10 @@ class BaseController extends Controller
         $persona = $persona == null ? Auth::user() : $persona;
 
         if($persona->recibirMails){
+          \Log::info('Mail en cola para '. $persona->mail .' con.');
           return $mail->queue($mailable);
         }
 
-        //\Log::info('Mail a: ' . Auth::user()->mail . ' no enviado por no aceptar notificaciones.');
+        \Log::info('Mail a: ' . Auth::user()->mail . ' no enviado por no aceptar notificaciones.');
     }
 }


### PR DESCRIPTION
## Descripción

Agrega un log simple para poder saber cuando se mandó un email.

Si arregla un defecto o incorpora una funcionalidad poné el link al issue:
Arregla #295 

Hubo fallas de envío de mail en la construcción de misiones y no sabemos por qué pasó.

## Checklist:

- [x] Revisé mi código
