### PR TITLE
Fix: se listaban las actividades como del usuario tan solo por haberl…

### DIFF
--- a/app/Exports/MisActividadesExport.php
+++ b/app/Exports/MisActividadesExport.php
@@ -47,7 +47,6 @@ class MisActividadesExport implements FromCollection, WithHeadings, WithColumnFo
             ->orderBy($sortField, $sortOrder);
 
         $result->where(function ($result) {
-            $result->orWhere('idPersonaModificacion', Auth::user()->idPersona);
             $result->orWhere('idPersonaCreacion', Auth::user()->idPersona);
             $result->orWhere('idCoordinador', Auth::user()->idPersona);
         });

--- a/app/Policies/InscripcionesPolicy.php
+++ b/app/Policies/InscripcionesPolicy.php
@@ -24,6 +24,6 @@ class InscripcionesPolicy
     {
         $actividad = Actividad::findOrFail($idActividad);
         return $user->hasAnyPermission(['tomar_asistencia', 'control_pagos'])
-            && ($user->idPersona === $actividad->idCoordinador || $user->hasRole('admin'));
+            && ($user->idPersona === $actividad->idPersonaCreacion || $user->idPersona === $actividad->idCoordinador || $user->hasRole('admin'));
     }
 }


### PR DESCRIPTION
## Descripción

Cambia el filtro para que aparezcan listadas las actividades donde el usuarios es coordinador o dueño

Si arregla un defecto o incorpora una funcionalidad poné el link al issue:
Arregla #298 

## ¿Cómo testeaste?

Describí que hiciste para verificar los cambios.

- [ ] Hice prueba creando actividad y cambiando el usuario coordinador

## Checklist:

- [x] Revisé mi código
