### PR TITLE
Arregla #230 mail cancelación actividad

### DIFF
--- a/app/Actividad.php
+++ b/app/Actividad.php
@@ -11,6 +11,7 @@ class Actividad extends Model
     protected $table = "Actividad";
     protected $primaryKey = "idActividad";
     protected $guarded = ['idActividad', 'pDNI'];
+    protected $fillable = ['nombreActividad', 'fechaInicio'];
     protected $dates =
         [
             'fechaCreacion', 'fechaModificacion',

--- a/app/Jobs/EnviarMailsCancelacionActividad.php
+++ b/app/Jobs/EnviarMailsCancelacionActividad.php
@@ -12,7 +12,7 @@ use Mail;
 
 class EnviarMailsCancelacionActividad implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable, InteractsWithQueue, Queueable;
 
     public $inscripcion;
 
@@ -21,9 +21,12 @@ class EnviarMailsCancelacionActividad implements ShouldQueue
      *
      * @return void
      */
-    public function __construct($inscripcion)
+    public function __construct(array $persona, array $actividad, array $pais)
     {
-        $this->inscripcion = $inscripcion;
+
+        $this->persona = \App\Persona::make($persona);
+        $this->actividad = \App\Actividad::make($actividad);
+        $this->pais = \App\Pais::make($pais);
     }
 
     /**
@@ -33,8 +36,8 @@ class EnviarMailsCancelacionActividad implements ShouldQueue
      */
     public function handle()
     {
-        if($this->inscripcion->persona->recibirMails){
-            Mail::to($this->inscripcion->persona->mail)->send(new CancelacionActividad($this->inscripcion));
+        if($this->persona->recibirMails){
+            Mail::to($this->persona->mail)->send(new CancelacionActividad($this->persona, $this->actividad, $this->pais));
         }
         //sleep(3);
     }

--- a/app/Mail/CancelacionActividad.php
+++ b/app/Mail/CancelacionActividad.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 
 class CancelacionActividad extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable;
 
     public $inscripcion;
     public $persona;
@@ -19,10 +19,11 @@ class CancelacionActividad extends Mailable
      *
      * @return void
      */
-    public function __construct($inscripcion)
+    public function __construct($persona, $actividad, $pais)
     {
-        $this->inscripcion = $inscripcion;
-        $this->persona = $inscripcion->persona;
+        $this->persona = $persona;
+        $this->actividad = $actividad;
+        $this->pais = $pais;
     }
 
     /**
@@ -33,8 +34,8 @@ class CancelacionActividad extends Mailable
     public function build()
     {
         return $this
-            ->subject('TECHO: ' . $this->inscripcion->actividad->nombreActividad . ' fue cancelada')
+            ->subject('TECHO: ' . $this->actividad->nombreActividad . ' fue cancelada')
             ->from('no-reply@techo.org')
-            ->view('emails.cancelacionActividad');
+            ->view('emails.cancelacionActividad',['persona' => $this->persona, 'actividad' => $this->actividad, 'pais' => $this->pais]);
     }
 }

--- a/app/Pais.php
+++ b/app/Pais.php
@@ -8,6 +8,7 @@ class Pais extends Model
 {
     protected $table = 'atl_pais';
     protected $primaryKey = 'id';
+    protected $fillable = ['nombre'];
     public $timestamps = false;
 
     public function provincias()

--- a/app/Persona.php
+++ b/app/Persona.php
@@ -14,6 +14,7 @@ class Persona extends Authenticatable
     protected $table = 'Persona';
     protected $primaryKey = 'idPersona';
     protected $hidden = ['password', 'remember_token'];
+    protected $fillable = ['recibirMails', 'nombres', 'unsubscribe_token', 'mail'];
 
     public function puntosEncuentro()
     {

--- a/resources/views/emails/cancelacionActividad.blade.php
+++ b/resources/views/emails/cancelacionActividad.blade.php
@@ -2,12 +2,12 @@
 
 @section('content')
     <p style="font-size: larger">
-        Hola {{$inscripcion->persona->nombres}},
+        Hola {{$persona->nombres}},
     </p>
     <p>
-        Te informamos que la actividad <strong>{{$inscripcion->actividad->nombreActividad}}</strong> de
-        TECHO - {{$inscripcion->actividad->pais->nombre}} que iniciaba el
-        {{$inscripcion->actividad->fechaInicio->format('d/m/Y')}}, ha sido <strong>CANCELADA</strong>
+        Te informamos que la actividad <strong>{{$actividad->nombreActividad}}</strong> de
+        TECHO - {{$pais->nombre}} que iniciaba el
+        {{$actividad->fechaInicio->format('d/m/Y')}}, ha sido <strong>CANCELADA</strong>
     </p>
     <p>
         Lamentamos cualquier inconveniente causado y te invitamos a entrar en el sitio de

--- a/tests/Feature/MailingTest.php
+++ b/tests/Feature/MailingTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Mail;
+use App\Jobs\EnviarMailsCancelacionActividad;
+use App\Mail\CancelacionActividad;
+
+class MailingTest extends TestCase
+{
+	use RefreshDatabase;
+
+    /** @test */
+    public function administrador_elimina_actividad()
+    {
+        $this->withoutExceptionHandling();
+
+        Mail::fake();
+
+		$persona = factory('App\Persona')->create();
+    	$permission = Permission::create(['name' => 'ver_backoffice']);
+		$persona->givePermissionTo($permission);
+		$permission = Permission::create(['name' => 'borrar_actividad']);
+		$persona->givePermissionTo($permission);
+
+		$persona_que_quiere_recibir_mail = factory('App\Persona')->create(['recibirMails' => true ]);
+
+    	$actividad = factory('App\Actividad')->create();
+    	$punto = $actividad->puntosEncuentro()->save(factory('App\PuntoEncuentro')->make());
+    	$inscripcion = $punto->inscripciones()->save(factory('App\Inscripcion')->make([
+    		'idActividad' => $actividad->idActividad,
+    		'idPersona' => $persona_que_quiere_recibir_mail->idPersona
+    	]));
+
+        $this->actingAs($persona)
+        	->delete('/admin/actividades/' . $actividad->idActividad)
+        	->assertRedirect('/admin/actividades/usuario');
+
+        $this->assertDatabaseMissing('Actividad', [ 'nombreActividad' => $actividad->nombreActividad]);
+
+        Mail::assertSent(CancelacionActividad::class, function ($mail) use ($actividad) {
+            return $mail->actividad->nombreActividad === $actividad->nombreActividad;
+        });
+    }
+}


### PR DESCRIPTION
## Descripción

Arregla el error que se da cuando intenta enviar notificaciones para una actividad que se eliminó.

Si arregla un defecto o incorpora una funcionalidad poné el link al issue:
Arregla #230 

## ¿Cómo testeaste?

Describí que hiciste para verificar los cambios.

- [x] tests/Feature/MailingTest.php


## Checklist:

- [x] Revisé mi código
- [x] Agregué tests que muestran que mi arreglo está bien o que mi funcionalidad anda.
