### PR TITLE
Resuelve 408 - Habilita boton guardar al cambiar opciones de notificaciones

### DIFF
--- a/resources/js/components/perfil/perfil.vue
+++ b/resources/js/components/perfil/perfil.vue
@@ -401,7 +401,14 @@
             },
              'user.localidad': function () {
                 this.formDirty = true;
+            },
+             'user.recibirMails': function () {
+                this.formDirty = true;
+            },
+             'user.acepta_marketing': function () {
+                this.formDirty = true;
             }
+
         },
         methods: {
             cancelar: function () {


### PR DESCRIPTION
## Descripción

Resolves #408 
El boton no se habilitaba al cambiar notificaciones, habia que cambiar otro campo

## ¿Cómo testeaste?
- [x] modifique el vue para que tomer el cambio sobre las notificaciones
- [x] Testee en frontend local


## Checklist:

- [x] Revisé mi código
- [ ] Agregué tests que muestran que mi arreglo está bien o que mi funcionalidad anda.
