### PR TITLE
solves #440 y #285

### DIFF
--- a/app/Http/Controllers/backoffice/ActividadesController.php
+++ b/app/Http/Controllers/backoffice/ActividadesController.php
@@ -93,8 +93,8 @@ class ActividadesController extends Controller
         $validator = $this->createValidator($request);
         if ($validator->passes()) {
             if ($this->guardarActividad($request, $actividad) && $this->crearGrupo($actividad)) {
-                $request->session()->put('mensaje', 'La actividad se creó correctamente');
-                return response('Actividad creada correctamente.', 200);
+                $request->session()->flash('mensaje', 'Actividad creada correctamente');
+                return response('Actividad creada correctamente', 200);
             } else {
                 return response('No se pudo crear la actividad', 500);
             }

--- a/app/Http/Controllers/backoffice/ActividadesController.php
+++ b/app/Http/Controllers/backoffice/ActividadesController.php
@@ -34,8 +34,7 @@ class ActividadesController extends Controller
         $datatableConfig = config('datatables.actividades');
         $fields = json_encode($datatableConfig['fields']);
         $sortOrder = json_encode($datatableConfig['sortOrder']);
-        isset($request->msg) ? Session::flash('mensaje', 'La actividad se eliminó correctamente') : false;
-        return view('backoffice.actividades.index', compact('fields', 'sortOrder', 'mensaje'));
+        return view('backoffice.actividades.index', compact('fields', 'sortOrder'));
     }
 
     /**
@@ -95,9 +94,9 @@ class ActividadesController extends Controller
         if ($validator->passes()) {
             if ($this->guardarActividad($request, $actividad) && $this->crearGrupo($actividad)) {
                 $request->session()->put('mensaje', 'La actividad se creó correctamente');
-                return response('Actividad guardada correctamente.', 200);
+                return response('Actividad creada correctamente.', 200);
             } else {
-                return response('No se pudo guardar la actividad', 500);
+                return response('No se pudo crear la actividad', 500);
             }
         }
 
@@ -251,7 +250,6 @@ class ActividadesController extends Controller
         $validator = $this->createValidator($request);
         if ($validator->passes()) {
             if ($this->guardarActividad($request, $actividad)) {
-                $request->session()->put('mensaje', 'La actividad se creó correctamente');
                 return response('Actividad guardada correctamente.', 200);
             } else {
                 return response('No se pudo guardar la actividad', 500);

--- a/resources/js/components/backoffice/actividades/actividades-show.vue
+++ b/resources/js/components/backoffice/actividades/actividades-show.vue
@@ -311,7 +311,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-md-2">
+            <div class="col-md-3">
                 <div class="form-group">
                     <div style="display: flex; flex-direction: column; align-items: center;">
                         <label>Confirmación por pago</label>

--- a/resources/js/components/backoffice/actividades/actividades-show.vue
+++ b/resources/js/components/backoffice/actividades/actividades-show.vue
@@ -782,7 +782,8 @@
 
                 //cambiar el boton a editar
                 var botonIncluirEditar = this.$refs.puntoEncuentro.$refs.botonIncluirEditar;
-                botonIncluirEditar.innerHTML="<i class='fa fa-edit'></i>  Editar";
+                botonIncluirEditar.className="btn btn-success pull-right";
+                botonIncluirEditar.innerHTML="<i class='fa fa-save'></i>  Guardar";
 
                 this.$refs.puntoEncuentro.idPuntoEncuentro = obj.obj.idPuntoEncuentro;
 

--- a/resources/views/backoffice/actividades/index.blade.php
+++ b/resources/views/backoffice/actividades/index.blade.php
@@ -15,9 +15,6 @@
     @if (Session::has('mensaje'))
         <div class="callout callout-success">
             <h4>{{ Session::get('mensaje') }}</h4>
-            @php
-                \Illuminate\Support\Facades\Session::remove('mensaje');
-            @endphp
         </div>
     @endif
 

--- a/resources/views/backoffice/actividades/mis_actividades/index.blade.php
+++ b/resources/views/backoffice/actividades/mis_actividades/index.blade.php
@@ -12,6 +12,15 @@
 @endsection
 
 @section('content')
+    @if (Session::has('mensaje'))
+        <div class="callout callout-success">
+            <h4>{{ Session::get('mensaje') }}</h4>
+            @php
+                \Illuminate\Support\Facades\Session::remove('mensaje');
+            @endphp
+        </div>
+    @endif
+    
     <div class="box">
         <div class="box-body  with-border">
             <div class="table-responsive">

--- a/resources/views/backoffice/actividades/mis_actividades/index.blade.php
+++ b/resources/views/backoffice/actividades/mis_actividades/index.blade.php
@@ -15,9 +15,6 @@
     @if (Session::has('mensaje'))
         <div class="callout callout-success">
             <h4>{{ Session::get('mensaje') }}</h4>
-            @php
-                \Illuminate\Support\Facades\Session::remove('mensaje');
-            @endphp
         </div>
     @endif
     

--- a/tests/Feature/ActividadesTest.php
+++ b/tests/Feature/ActividadesTest.php
@@ -43,7 +43,7 @@ class ActividadesTest extends TestCase
 
         $this->actingAs($persona)
         	->post('/admin/actividades/crear', $actividad_t)
-        	->assertSeeText("Actividad guardada correctamente.");
+        	->assertSeeText("Actividad creada correctamente.");
 
         $this->assertDatabaseHas('Actividad', [ 'nombreActividad' => $actividad->nombreActividad])
         	->assertDatabaseHas('PuntoEncuentro', [ 'punto' => $punto->punto ]);

--- a/tests/Feature/ActividadesTest.php
+++ b/tests/Feature/ActividadesTest.php
@@ -18,9 +18,10 @@ class ActividadesTest extends TestCase
     {
     	$this->withoutExceptionHandling();
 
+        $this->seed('PermisosSeeder');
+
     	$persona = factory('App\Persona')->create();
-    	$permission = Permission::create(['name' => 'ver_backoffice']);
-		$persona->givePermissionTo($permission);
+		$persona->assignRole('coordinador');
 
     	$actividad = factory('App\Actividad')->make();
 
@@ -43,7 +44,20 @@ class ActividadesTest extends TestCase
 
         $this->actingAs($persona)
         	->post('/admin/actividades/crear', $actividad_t)
-        	->assertSeeText("Actividad creada correctamente.");
+        	->assertSeeText('Actividad creada correctamente')
+            ->assertSessionHas('mensaje', 'Actividad creada correctamente');
+
+        //funciona hacer un flash
+        $this->actingAs($persona)
+            ->get('/admin/actividades/usuario')
+            ->assertSeeText('Actividad creada correctamente')
+            ->assertSessionMissing('mensaje');
+
+        //no se debería ver más el mensaje
+        $this->actingAs($persona)
+            ->get('/admin/actividades/usuario')
+            ->assertDontSeeText('Actividad creada correctamente')
+            ->assertSessionMissing('mensaje');
 
         $this->assertDatabaseHas('Actividad', [ 'nombreActividad' => $actividad->nombreActividad])
         	->assertDatabaseHas('PuntoEncuentro', [ 'punto' => $punto->punto ]);


### PR DESCRIPTION
…actividades y mensajes

## Descripción
Resolves #440 
Resolves #285

440 
-Se modifico el boton que decia editar por guardar (se cambio class para success, icono y texto)
285 
-Se quito mensaje al compact del index (no era utilizado despues y en php 7.3 daba error undefinded
-Al editar actividad se quito mesaje de session porque el mismo se muestra por request
-Se modifico template de mis actividades para que muestre el mensaje al crear o eliminar actividad (ya que al hacerlo el sistema redirije a esa pantalla y no a la "Ver Todas")

¿Otra cosa? contá el contexto y la motivación.
estoy re manija en grecia y quiero aprender mas laravel, asi que esto es una entrada en calor

## ¿Cómo testeaste?
el 440 visualmente
el 285 
1- cree una actividad y al redirigirme automaticamente a "mis actividades" me mostraba mensaje de 2- actividad creada
3- Al ver todas las actividades, no me muestra mensaje
4- Edito actividad, me muestra mensaje dentro de la actividad
5- vuelvo a todas y no me lo muestra (tampoco en mis actividades)
6- Elimino actividad y me muestra sobre "mis actividad" mensaje de actividad eliminada
7- no me muestra mensaje cuando voy a ver todas las actividades


Checklist:
- [X] Revisé mi código