### PR TITLE
quick fix 291 y 294 - agrega columna pais

### DIFF
--- a/app/Exports/ActividadesExport.php
+++ b/app/Exports/ActividadesExport.php
@@ -38,11 +38,13 @@ class ActividadesExport implements FromCollection, WithHeadings, WithColumnForma
                     'atl_oficinas.nombre AS oficina',
                     'Tipo.nombre AS tipoActividad',
                     'atl_CategoriaActividad.nombre as nombreCategoria',
+                    'atl_pais.nombre AS pais',
                 ]
             )
             ->leftJoin('atl_oficinas', 'Actividad.idOficina', '=', 'atl_oficinas.id')
             ->leftJoin('Tipo', 'Tipo.idTipo', '=', 'Actividad.idTipo')
             ->leftJoin('atl_CategoriaActividad', 'Tipo.idCategoria', '=', 'atl_CategoriaActividad.id')
+            ->leftJoin('atl_pais', 'Actividad.idPais', '=', 'atl_pais.id')
             ->orderBy($sortField, $sortOrder);
 
         if ($this->filter) {
@@ -89,6 +91,7 @@ class ActividadesExport implements FromCollection, WithHeadings, WithColumnForma
             'Oficina',
             'Tipo de Actividad',
             'Categoría de la Actividad',
+            'País',
         ];
     }
 }

--- a/app/Exports/MisActividadesExport.php
+++ b/app/Exports/MisActividadesExport.php
@@ -32,6 +32,7 @@ class MisActividadesExport implements FromCollection, WithHeadings, WithColumnFo
             ->leftJoin('atl_oficinas', 'Actividad.idOficina', '=', 'atl_oficinas.id')
             ->leftJoin('Tipo', 'Tipo.idTipo', '=', 'Actividad.idTipo')
             ->leftJoin('atl_CategoriaActividad', 'Tipo.idCategoria', '=', 'atl_CategoriaActividad.id')
+            ->leftJoin('atl_pais', 'Actividad.idPais', '=', 'atl_pais.id')
             ->select(
                 [
                     'Actividad.idActividad AS id',
@@ -42,6 +43,7 @@ class MisActividadesExport implements FromCollection, WithHeadings, WithColumnFo
                     'atl_oficinas.nombre AS oficina',
                     'Tipo.nombre AS tipoActividad',
                     'atl_CategoriaActividad.nombre as nombreCategoria',
+                    'atl_pais.nombre AS pais', 
                 ]
             )
             ->whereNull('deleted_at')

--- a/config/datatables.php
+++ b/config/datatables.php
@@ -55,6 +55,13 @@ return [
                 'dataClass' => 'text-center',
                 'title' => 'Estado',
             ],
+            [
+               'name' => 'pais',
+                'sortField' => 'pais',
+                'titleClass' => 'text-center',
+                'dataClass' => 'text-center',
+                'title' => 'Pais',
+            ],
 //            [
 //                'name' => '__component:mis-actividades',
 //                'title' => 'Acciones',
@@ -148,6 +155,13 @@ return [
                 'titleClass' => 'text-center',
                 'dataClass' => 'text-center',
                 'title' => 'Estado',
+            ],
+            [
+               'name' => 'pais',
+                'sortField' => 'pais',
+                'titleClass' => 'text-center',
+                'dataClass' => 'text-center',
+                'title' => 'Pais',
             ],
             // [
             //   name' => 'nickname',

--- a/resources/views/backoffice/actividades/show.blade.php
+++ b/resources/views/backoffice/actividades/show.blade.php
@@ -77,7 +77,7 @@
                                         api-url={{ '/admin/ajax/grupos/'. $miembros['idRaiz'] .'/miembros' }}
                                         fields="{{ $fieldsMiembros }}"
                                         sort-order = "{{ $sortOrderMiembros }}"
-                                        placeholder-text="Buscar por Nombre, Oficina, Tipo o Estado"
+                                        placeholder-text="Buscar por Nombre o Rol"
                                         id-grupo-raiz = "{{ $miembros['idRaiz'] }}"
                                         id-actividad = "{{ $actividad->idActividad }}"
                                         ref="miembrosTabla"


### PR DESCRIPTION
## Descripción
Solves #291  y #294 

## ¿Cómo testeaste?
#294
Visualmente viendo como desde el backend ambas consultas de actividades (mis actividades y todas) muestran el campo Pais correctamente

#291
Para este modifique el texto defecto que aparece en el filtro a los que realmente filtra, probe filtrando por ambos campos, cambiandolos y volviendo a filtrar sin problemas u errores

## Checklist:

- [X] Revisé mi código
- [ ] Agregué tests que muestran que mi arreglo está bien o que mi funcionalidad anda.
