### PR TITLE
Incorpora 430 eliminar personas como administrador

### DIFF
--- a/app/Http/Controllers/backoffice/UsuariosController.php
+++ b/app/Http/Controllers/backoffice/UsuariosController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\backoffice;
 use App\Persona;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Session;
+
 
 class UsuariosController extends Controller
 {
@@ -49,5 +51,15 @@ class UsuariosController extends Controller
 
         $edicion = false;
         return view('backoffice.usuarios.show', compact('edicion', 'arrUsuario', 'usuario'));
+    }
+
+    public function delete(Persona $id)
+    {
+        if ($id->delete()){
+            Session::flash('mensaje', 'Persona eliminada correctamente');
+        } else {
+            Session::flash('mensaje', 'Ocurrio un error al querer eliminar a la Persona');
+        }
+        return redirect()->to('/admin/usuarios');
     }
 }

--- a/app/Persona.php
+++ b/app/Persona.php
@@ -9,14 +9,17 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Mail;
 use Spatie\Permission\Traits\HasRoles;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
 
 class Persona extends Authenticatable implements MustVerifyEmail
 {
-    use Notifiable, HasRoles;
+    use Notifiable, HasRoles, SoftDeletes;
     protected $table = 'Persona';
     protected $primaryKey = 'idPersona';
     protected $hidden = ['password', 'remember_token'];
     protected $fillable = ['recibirMails', 'nombres', 'unsubscribe_token', 'mail'];
+    protected $dates = ['deleted_at'];
 
     public function routeNotificationForMail($notification)
     {

--- a/database/migrations/2019_09_26_124840_incluye_campo_deleted_at_en_persona.php
+++ b/database/migrations/2019_09_26_124840_incluye_campo_deleted_at_en_persona.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class IncluyeCampoDeletedAtEnPersona extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('Persona', function ($table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table("Persona", function ($table) {
+            $table->dropSoftDeletes();
+        });
+    }
+}

--- a/database/seeds/BorrarPersonasSeeder.php
+++ b/database/seeds/BorrarPersonasSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use \Spatie\Permission\Models\Role as Role;
+use \Spatie\Permission\Models\Permission as Permission;
+
+class BorrarPersonasSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $permission = Permission::create(['name' => 'borrar_usuarios']);
+
+        $admin = Role::findByName('admin');
+
+        $admin->givePermissionTo($permission);
+    }
+}

--- a/database/seeds/PermisosSeeder.php
+++ b/database/seeds/PermisosSeeder.php
@@ -14,5 +14,6 @@ class PermisosSeeder extends Seeder
         $this->call(RolesTableSeeder::class);
         $this->call(PermissionsTableSeeder::class);
         $this->call(RolePermissionsSeeder::class);
+        $this->call(BorrarPersonasSeeder::class);
     }
 }

--- a/database/seeds/PermissionsTableSeeder.php
+++ b/database/seeds/PermissionsTableSeeder.php
@@ -23,5 +23,6 @@ class PermissionsTableSeeder extends Seeder
         Permission::create(['name' => 'administrar_imagenes']);
         Permission::create(['name' => 'ver_usuarios']);
         Permission::create(['name' => 'editar_usuarios']);
+        Permission::create(['name' => 'borrar_usuarios']);
     }
 }

--- a/database/seeds/PermissionsTableSeeder.php
+++ b/database/seeds/PermissionsTableSeeder.php
@@ -23,6 +23,5 @@ class PermissionsTableSeeder extends Seeder
         Permission::create(['name' => 'administrar_imagenes']);
         Permission::create(['name' => 'ver_usuarios']);
         Permission::create(['name' => 'editar_usuarios']);
-        Permission::create(['name' => 'borrar_usuarios']);
     }
 }

--- a/database/seeds/RolePermissionsSeeder.php
+++ b/database/seeds/RolePermissionsSeeder.php
@@ -32,7 +32,6 @@ class RolePermissionsSeeder extends Seeder
                 'ver_backoffice',
                 'administrar_imagenes',
                 'ver_usuarios',
-                'borrar_usuarios'
             ])->get();
 
         $coordinador->givePermissionTo($permissions);

--- a/database/seeds/RolePermissionsSeeder.php
+++ b/database/seeds/RolePermissionsSeeder.php
@@ -31,7 +31,8 @@ class RolePermissionsSeeder extends Seeder
                 'ver_mis_actividades',
                 'ver_backoffice',
                 'administrar_imagenes',
-                'ver_usuarios'
+                'ver_usuarios',
+                'borrar_usuarios'
             ])->get();
 
         $coordinador->givePermissionTo($permissions);

--- a/resources/js/components/backoffice/crudFooter.vue
+++ b/resources/js/components/backoffice/crudFooter.vue
@@ -115,7 +115,7 @@
             eliminar: function () {
                 let self = this;
                 self.$refs.confirmar.openSimplert({
-                    title: 'Borrar Actividad',
+                    title: 'Eliminar Registro',
                     message: "Estás por eliminar este registro, se borrará permanentemente y no podrá recuperarse. ¿Deseas continuar?",
                     useConfirmBtn: true,
                     isShown: true,

--- a/resources/js/components/backoffice/usuarios/usuario-form.vue
+++ b/resources/js/components/backoffice/usuarios/usuario-form.vue
@@ -267,6 +267,7 @@
 
 
             Event.$on('guardar', this.guardar);
+            Event.$on('eliminar', this.eliminar);
             Event.$on('editar', this.editar);
         },
         computed: {
@@ -382,6 +383,10 @@
                         }
                     });
 
+            },
+            eliminar(){
+                let form = document.getElementById('formDelete');
+                form.submit();
             }
         }
     }

--- a/resources/js/components/evaluaciones/evaluarActividad.vue
+++ b/resources/js/components/evaluaciones/evaluarActividad.vue
@@ -68,7 +68,7 @@
                         >
                             Enviar Evaluación
                         </button>
-                        <p class="pull-right" v-if="enviado"><strong>¡Gracias por tu opinión!</strong></p>
+                        <p class="pull-right" v-if="enviado"><strong>Enviado</strong></p>
                         <p class="pull-right" v-if="evaluacionPasada && !enviado">La fecha de fin de las evaluaciones ya pasó &#9785;</p>
                         <p class="red" v-if="error">
                             <i class="fas fa-exclamation"></i> &nbsp;

--- a/resources/js/components/evaluaciones/evaluarPersona.vue
+++ b/resources/js/components/evaluaciones/evaluarPersona.vue
@@ -107,7 +107,7 @@
                         >
                             Enviar Evaluación
                         </button>
-                        <p class="pull-right" v-if="enviado"><strong>¡Gracias por tu opinión!</strong></p>
+                        <p class="pull-right" v-if="enviado"><strong>Enviado</strong></p>
                         <p class="pull-right" v-if="evaluacionPasada & !enviado">La fecha de fin de las evaluaciones ya pasó &#9785;</p>
                         <p class="red" v-if="error">
                             <i class="fas fa-exclamation"></i> &nbsp;

--- a/resources/views/backoffice/usuarios/index.blade.php
+++ b/resources/views/backoffice/usuarios/index.blade.php
@@ -12,6 +12,11 @@
 @endsection
 
 @section('content')
+    @if (Session::has('mensaje'))
+        <div class="callout callout-success">
+            <h4>{{ Session::get('mensaje') }}</h4>
+        </div>
+    @endif
     <div class="box">
         <div class="box-body  with-border">
             <usuarios-datatable

--- a/resources/views/backoffice/usuarios/show.blade.php
+++ b/resources/views/backoffice/usuarios/show.blade.php
@@ -53,6 +53,6 @@
             cancelar-url="/admin/usuarios"
             edicion="{{ $edicion }}"
             can-editar="true"
-            can-borrar="{{Auth::user()->hasPermissionTo('borrar_actividad')}}"
+            can-borrar="{{Auth::user()->hasPermissionTo('borrar_usuarios')}}"
     ></crud-footer>
 @endsection

--- a/resources/views/backoffice/usuarios/show.blade.php
+++ b/resources/views/backoffice/usuarios/show.blade.php
@@ -1,9 +1,17 @@
 @extends('backoffice.main')
 
-@section('page_title', 'Usuario: ' . $usuario->nombreCompleto)
+@section('page_title', 'Persona: ' . $usuario->nombreCompleto)
 
 
 @section('content')
+
+ <form method="POST" id="formDelete"
+          action="{{ action('backoffice\UsuariosController@delete', ['id' => $usuario->idPersona]) }}">
+
+        <input type="hidden" value="DELETE" name="_method">
+        {{ csrf_field() }}
+</form>
+
 <div class="nav-tabs-custom">
         <ul class="nav nav-tabs" style="border-bottom: 3px solid #d2d6de; padding-bottom: 2px;">
             <li class="active">
@@ -45,5 +53,6 @@
             cancelar-url="/admin/usuarios"
             edicion="{{ $edicion }}"
             can-editar="true"
+            can-borrar="{{Auth::user()->hasPermissionTo('borrar_actividad')}}"
     ></crud-footer>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -148,7 +148,7 @@ Route::prefix('/admin')->middleware(['verified', 'auth', 'can:accesoBackoffice']
     Route::post('/usuarios/registrar', 'backoffice\ajax\UsuariosController@store')->middleware('role:admin');
     Route::get('/usuarios/{id}', 'backoffice\UsuariosController@show')->middleware('role:admin');
     Route::post('/usuarios/{id}/editar', 'backoffice\ajax\UsuariosController@update')->middleware('role:admin');
-    Route::delete('/usuarios/{id}', 'backoffice\UsuariosController@delete')->middleware('role:admin');
+    Route::delete('/usuarios/{id}', 'backoffice\UsuariosController@delete')->middleware('permission:borrar_usuarios');
 
     //panel de usuario
     Route::get('/ajax/usuarios/{id}/inscripciones', 'backoffice\ajax\UsuariosController@inscripciones')

--- a/routes/web.php
+++ b/routes/web.php
@@ -148,6 +148,7 @@ Route::prefix('/admin')->middleware(['verified', 'auth', 'can:accesoBackoffice']
     Route::post('/usuarios/registrar', 'backoffice\ajax\UsuariosController@store')->middleware('role:admin');
     Route::get('/usuarios/{id}', 'backoffice\UsuariosController@show')->middleware('role:admin');
     Route::post('/usuarios/{id}/editar', 'backoffice\ajax\UsuariosController@update')->middleware('role:admin');
+    Route::delete('/usuarios/{id}', 'backoffice\UsuariosController@delete')->middleware('role:admin');
 
     //panel de usuario
     Route::get('/ajax/usuarios/{id}/inscripciones', 'backoffice\ajax\UsuariosController@inscripciones')

--- a/tests/Feature/AdministrarUsuariosTest.php
+++ b/tests/Feature/AdministrarUsuariosTest.php
@@ -70,6 +70,29 @@ class AdministrarUsuariosTest extends TestCase
         $this->assertSoftDeleted('Persona', [ 'idPersona' => $jose->idPersona ]);
     }
 
+    /** @test */
+    public function coordinador_no_puede_eliminar_usuario()
+    {
+        //$this->withoutExceptionHandling();
+
+        $this->seed('PermisosSeeder');
+
+        $coordi = factory('App\Persona')->create();
+        $coordi->assignRole('coordinador');
+
+        $jose = factory('App\Persona')->create();
+
+        $this->actingAs($coordi)
+            ->delete('/admin/usuarios/' . $jose->idPersona)
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('Persona', [
+            'idPersona' => $jose->idPersona,
+            'deleted_at' => null
+        ]);
+
+    }
+
     public function crear_usuario_caracter_internacional()
      {
         $this->withoutExceptionHandling();

--- a/tests/Feature/AdministrarUsuariosTest.php
+++ b/tests/Feature/AdministrarUsuariosTest.php
@@ -50,6 +50,26 @@ class AdministrarUsuariosTest extends TestCase
         $this->assertDatabaseHas('Persona', [ 'nombres' => 'Modificado' ]);
     }
 
+
+    /** @test */
+    public function administrador_puede_eliminar_usuario()
+    {
+        $this->withoutExceptionHandling();
+
+        $this->seed('PermisosSeeder');
+
+        $admin = factory('App\Persona')->create();
+        $admin->assignRole('admin');
+
+        $jose = factory('App\Persona')->create();
+
+        $this->actingAs($admin)
+            ->delete('/admin/usuarios/' . $jose->idPersona)
+            ->assertStatus(302);
+
+        $this->assertSoftDeleted('Persona', [ 'idPersona' => $jose->idPersona ]);
+    }
+
     public function crear_usuario_caracter_internacional()
      {
         $this->withoutExceptionHandling();


### PR DESCRIPTION
## Descripción
Resolves #430 
Segun el pedido de Jorgito arme la funcionalidad para que solo los admin puedan borrar usuarios. Los mismos se elimnan de forma soft (quedan en base pero con fecha en el campo deleted_at) 

Resolves #211 
se cambia texto a enviado, probe visualmente en la app

¿Otra cosa? contá el contexto y la motivación.
el capo de jorgito que levanto este pedido y ahora lo tenemos listo, CRACK

## ¿Cómo testeaste?
Lo testee borrando un usuario y viendo que no apareciese mas en la lista de personas desde la web, despues tambien corrobore que apareciera con fecha en deleted_at.

Este pull request es un pedido de validacion, porque el usuario una vez eliminado no se ve desde las actividades (como inscripto) pero si queda en la base su inscripcion y evaluacion (como para levantar en estadisticas)

Describí que hiciste para verificar los cambios.

- [X] Arme test de usuario
- [X] Corri test ok
- [X] Borre usuario
- [X] chequee que no aparezca en la vista del back
- [X] Chequee que me quede en base de datos y con fecha en campo deleted_at

## Checklist:

- [X] Revisé mi código
- [X] Agregué tests que muestran que mi arreglo está bien o que mi funcionalidad anda.
