### PR TITLE
Fix 488 283 477 solo evalua presente y entre fechas

### DIFF
--- a/app/Http/Controllers/backoffice/ActividadesController.php
+++ b/app/Http/Controllers/backoffice/ActividadesController.php
@@ -327,24 +327,24 @@ class ActividadesController extends Controller
         $v = Validator::make(
             $request->all(),
             [
+                'nombreActividad'           => 'required',
                 'coordinador.idPersona'     => 'required | numeric',
-                'descripcion'               => 'required',
-                'fechaFin'                  => ['required', 'date', new FechaFinActividad($request->fechaInicio)],
+                'tipo.categoria.id'         => 'required',
+                'idTipo'                    => 'required',
+                'oficina.id'                => 'required',
                 'fechaInicio'               => 'required | date',
+                'fechaFin'                  => ['required', 'date', new FechaFinActividad($request->fechaInicio)], 
                 'fechaInicioInscripciones'  => 'required | date | before_or_equal:fechaInicio',
                 'fechaFinInscripciones'     => ['required', 'date', new FechaFinActividad($request->fechaInicioInscripciones), 'before_or_equal:fechaInicio'],
                 'fechaInicioEvaluaciones'   => 'required | date | after_or_equal:fechaFin',
                 'fechaFinEvaluaciones'      => ['required', 'date', new FechaFinActividad($request->fechaInicioEvaluaciones), 'after_or_equal:fechaInicioEvaluaciones'],
-                'idTipo'                    => 'required',
-                'inscripcionInterna'        => 'required',
-                'limiteInscripciones'       => 'numeric',
-                'mensajeInscripcion'        => 'required',
-                'nombreActividad'           => 'required',
-                'oficina.id'                => 'required',
+                'descripcion'               => 'required',
                 'pais.id'                   => 'required',
                 'provincia.id'              => 'required',
                 'puntos_encuentro'          => [new PuntoEncuentroRule],
-                'tipo.categoria.id'         => 'required',
+                'limiteInscripciones'       => 'numeric',                
+                'inscripcionInterna'        => 'required',
+                'mensajeInscripcion'        => 'required',
             ], $messages
         );
 

--- a/resources/js/components/perfil/btnMisActividades.vue
+++ b/resources/js/components/perfil/btnMisActividades.vue
@@ -2,7 +2,7 @@
     <div class="contenedor">
         <simplert ref="confirmar"></simplert>
         <button
-                v-if="actividadPasada && periodoDeEvaluacionYaComenzo"
+                v-if="actividadPasada && periodoDeEvaluacionYaComenzo && inscripcionPresente"
                 class="btn btn-sm btn-info"
                 @click="ir_a_evaluar"
         >
@@ -35,13 +35,14 @@
         },
         computed: {
             actividadPasada: function () {
-                let aver = moment().isAfter(moment(this.rowData.fechaFin, "DD/MM/YYYY mm:ss"));
-                //debugger;
-                return moment().isAfter(moment(this.rowData.fechaFin, "DD/MM/YYYY mm:ss"));
+                return moment().isAfter(moment(this.rowData.fechaFin, "DD/MM/YYYY hh:mm:ss"));
             },
             periodoDeEvaluacionYaComenzo: function () {
-                return moment().isAfter(moment(this.rowData.fechaInicioEvaluaciones, "DD/MM/YYYY mm:ss")) &&
-                    moment().isBefore(moment(this.rowData.fechaFinEvaluaciones, "DD/MM/YYYY mm:ss"))
+                return moment().isSameOrAfter(moment(this.rowData.fechaInicioEvaluaciones, "DD/MM/YYYY hh:mm:ss")) &&
+                    moment().isSameOrBefore(moment(this.rowData.fechaFinEvaluaciones, "DD/MM/YYYY hh:mm:ss"))
+            },
+            inscripcionPresente: function () {
+                return this.rowData.presente;
             }
         },
         watch: {


### PR DESCRIPTION
## Descripción
Con este cambio se reordena descripción de errores al crear actividad #283 y se corrije botón "Ver Evaluaciones" que estaba tomando mal el entre fechas #488 . También se agrego condición para que solo lo vea quien este inscrito y presente

Resolves #283 
Resolves #488 

## ¿Cómo testeaste?
Visualmente y también ya están los test aprobados y los tickets cerrados sobre el sandbox

## Checklist:

- [X] Revisé mi código
- [X] Tickets aprobados en testing, listo para producción
