### PR TITLE
Fix-fechaActividad en Exportar Inscriptos y Validacion Pais en registro

### DIFF
--- a/app/Exports/InscripcionesGeneralExport.php
+++ b/app/Exports/InscripcionesGeneralExport.php
@@ -33,7 +33,7 @@ class InscripcionesGeneralExport implements FromCollection, WithHeadings, WithCo
             ->join('Actividad', 'Actividad.idActividad', '=', 'Inscripcion.idActividad')
             ->join('Tipo', 'Tipo.idTipo', '=', 'Actividad.idTipo')
             ->join('atl_CategoriaActividad', 'atl_CategoriaActividad.id', '=', 'Tipo.idCategoria')
-            ->select(DB::raw('dni, nombres, apellidoPaterno, telefonoMovil, mail, fechaNacimiento, sexo, Inscripcion.fechaInscripcion, presente, rol, Actividad.nombreActividad, atl_CategoriaActividad.nombre as categoria, Tipo.nombre as tipo'))
+            ->select(DB::raw('dni, nombres, apellidoPaterno, telefonoMovil, mail, fechaNacimiento, sexo, Inscripcion.fechaInscripcion, presente, rol, Actividad.nombreActividad, atl_CategoriaActividad.nombre as categoria, Tipo.nombre as tipo, Actividad.fechaInicio'))
             ->whereYear('Inscripcion.created_at', $año);
 
         if($pais) $consulta->where('Actividad.idPais', $pais);
@@ -58,7 +58,8 @@ class InscripcionesGeneralExport implements FromCollection, WithHeadings, WithCo
             'rol',
             'actividad',
             'categoría',
-            'tipo'
+            'tipo',
+            'fecha de la actividad'
         ];
     }
 
@@ -70,6 +71,9 @@ class InscripcionesGeneralExport implements FromCollection, WithHeadings, WithCo
                 break;
             case 'F':
                 $genero = 'Femenino';
+                break;
+            case 'X':
+                $genero = 'Otro';
                 break;
             default:
                 $genero = 'Sin Especificar';
@@ -91,6 +95,7 @@ class InscripcionesGeneralExport implements FromCollection, WithHeadings, WithCo
             $query->nombreActividad,
             $query->categoria,
             $query->tipo,
+            Date::dateTimeToExcel(Carbon::parse($query->fechaInicio))
         ];
     }
 
@@ -99,6 +104,7 @@ class InscripcionesGeneralExport implements FromCollection, WithHeadings, WithCo
         return [
             'F' => NumberFormat::FORMAT_DATE_DDMMYYYY,
             'H' => NumberFormat::FORMAT_DATE_DDMMYYYY,
+            'N' => NumberFormat::FORMAT_DATE_DDMMYYYY,
         ];
     }
 

--- a/resources/js/components/registro.vue
+++ b/resources/js/components/registro.vue
@@ -147,6 +147,7 @@
                             <b-form-radio-group id="radios2" v-model="user.sexo">
                                 <b-form-radio value="F">Femenino</b-form-radio>
                                 <b-form-radio value="M">Masculino</b-form-radio>
+                                <b-form-radio value="X">Otro</b-form-radio>
                                 <b-form-radio value="O">Prefiero no decirlo</b-form-radio>
                             </b-form-radio-group>
                         </b-form-group>
@@ -387,7 +388,10 @@
         'user.sexo': function() { this.validar_data('sexo') },
         'user.dni': function() { this.validar_data('dni') },
         'user.telefono': function() { this.validar_data('telefono') },
-        'user.pais': function() { this.traer_provincias() },
+        'user.pais': function() { 
+            this.validar_data('pais') 
+            this.traer_provincias() 
+        },
         'user.provincia': function() { this.traer_localidades() }
       },
       methods: {


### PR DESCRIPTION
## Descripción
- Se agregó validación de Pais el momento de registro #223 
- aproveche para agregar Genero "Otro" al momento de seleccionar
- Al exportar inscriptos se suma columna "Fecha Actividad #456 

Resolves #223 
Resolves #456 

## ¿Cómo testeaste?
- Cree un usuario, valide que el campo pais fuera validado automaticamente, creando el usuario con Genero Otro, chequee en base de datos OK
- Descargue Inscriptos desde el boton de estadisticas generales y vi la columna en el excel en cuestion

## Checklist:

- [X] Revisé mi código