### PR TITLE
incorpora 436 - estadisticas al home

### DIFF
--- a/app/Http/Controllers/EstadisticasController.php
+++ b/app/Http/Controllers/EstadisticasController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class EstadisticasController extends Controller
+{
+
+    public function voluntades_movilizadas()
+    {
+        $inscriptosPresentes = \App\Inscripcion::whereYear('fechaInscripcion', now()->year)
+        ->where('presente', 1)
+        ->count();
+
+
+
+        return $inscriptosPresentes;
+    }
+
+    public function actividades()
+    {
+        $actividades = \App\Actividad::join('Tipo', 'Tipo.idTipo', '=', 'Actividad.idTipo')
+            ->join('atl_CategoriaActividad', 'atl_CategoriaActividad.id', '=', 'Tipo.idCategoria')
+            ->select(DB::raw('atl_CategoriaActividad.nombre, count(*) cantidad'))
+            ->whereYear('fechaCreacion', now()->year) 
+            ->whereIn('atl_CategoriaActividad.id', ['1', '2'])
+            ->groupBy('atl_CategoriaActividad.nombre');
+
+        
+        return $actividades->get();
+    }
+
+    public function personas_movilizadas()
+    {
+        $personas = \App\Persona::join('Inscripcion', 'Persona.idPersona', '=', 'Inscripcion.IdPersona')
+            ->whereYear('Inscripcion.fechaInscripcion', now()->year)
+            ->where('Inscripcion.presente', 1)
+            ->groupBy('Persona.idPersona')
+            ->select(DB::raw('Persona.idPersona, count(*)'))
+            ->get();
+
+        return $personas; 
+    }
+}

--- a/app/Http/Controllers/EstadisticasController.php
+++ b/app/Http/Controllers/EstadisticasController.php
@@ -27,8 +27,9 @@ class EstadisticasController extends Controller
             ->join('atl_CategoriaActividad', 'atl_CategoriaActividad.id', '=', 'Tipo.idCategoria')
             ->select(DB::raw('atl_CategoriaActividad.nombre, count(*) cantidad'))
             ->whereYear('fechaCreacion', now()->year) 
-            ->whereIn('atl_CategoriaActividad.id', ['1', '2'])
-            ->groupBy('atl_CategoriaActividad.nombre');
+            ->whereIn('atl_CategoriaActividad.id', ['2', '1'])
+            ->groupBy('atl_CategoriaActividad.nombre')
+            ->orderBy('cantidad', 'DESC');
 
         
         return $actividades->get();

--- a/config/app.php
+++ b/config/app.php
@@ -37,6 +37,7 @@ return [
     'userreport_token' => env('USERREPORT_TOKEN'),
     'google_analytics_token' => env('GOOGLE_ANALYTICS_TOKEN'),
     'docs' => env('APP_DOCS', false),
+    'estadisticas' => env('APP_ESTADISTICAS', false),
 
 
     /*

--- a/public/css/atlas.css
+++ b/public/css/atlas.css
@@ -179,6 +179,7 @@ code {
     position: relative;
     color: #ffffff;
     font-family: Montserrat, sans-serif;
+    flex-flow: column;
 }
 
 a {
@@ -274,13 +275,40 @@ a {
 .techo-hero h1 {
     font-size: 5vw;
     margin: auto;
-    position: absolute;
+    /*position: absolute;*/
     z-index: 1;
     font-weight: bold;
     vertical-align: middle;
     line-height: normal;
-    padding-bottom: 3rem;
+    padding-bottom: 1rem;
     text-shadow: 0 0 16px #60676a;
+}
+
+.techo-hero h1.mobile {
+    display: none;
+}
+
+.techo-hero-text {
+    width: 100%;
+    flex-flow: column;
+    display: flex;
+    position: absolute;
+}
+
+.estadisticas-publicas {
+    flex-flow: row;
+    display: flex;
+    justify-content: space-around;
+    background-color: #8481816b;
+    font-weight: 500;
+    font-size: 1.25rem;
+    text-shadow: 0 0 16px #60676a;
+    padding: 2vw 0;
+}
+
+.estadisticas-publicas h3 {
+    font-size: 2.5rem;
+    font-weight: 700;
 }
 
 .techo-hero h2 {
@@ -390,49 +418,60 @@ footer.inscripcion-bar .text-primary {
 
 /* Media queries */
 
-@media (max-width: 543px) {
+@media (max-width: 678px) {
     h1.text-primary {
-        font-size:1.5rem; /*1rem = 16px*/
+        font-size: 1.5rem; /*1rem = 16px*/
     }
 
     main {
         margin-bottom: 175px;
     }
-}
-@media (min-width: 544px) {
-    .techo-hero h1, .techo-hero h2 {
-        font-size:2.5rem; /*1rem = 16px*/
+
+    .techo-hero h1.mobile {
+        position: absolute;
+        top: 2rem;
+        font-size: 7vw;
     }
 
-    h1 {
-        font-size:2.5rem; /*1rem = 16px*/
+    .techo-hero h1.desktop {
+        display: none;
     }
 
-    main {
-        margin-bottom: 175px;
-    }
-}
-
-/* Medium devices (tablets, 768px and up) The navbar toggle appears at this breakpoint */
-@media (min-width: 768px) {
-    .techo-hero h1, .techo-hero h2 {
-        font-size:2.5rem; /*1rem = 16px*/
-        padding-bottom: 5rem;
+    .techo-hero h1.mobile {
+        display: block;
     }
 
-    h1 {
-        font-size:2.5rem; /*1rem = 16px*/
+    .techo-hero-text {
+        position: initial;
+        background-color: #0192ddff;
     }
 
-    main {
-        margin-bottom: 175px;
+    .estadisticas-publicas {
+        flex-direction: column;
     }
+
+    .estadisticas-publicas h3 {
+        font-size: 1.5rem;
+    }
+
+    .estadisticas-publicas span {
+        font-size: 1rem;
+        font-weight: 400;
+    }
+
+    .estadisticas-publicas div {
+        flex-direction: column;
+        display: flex;
+        margin: 12px 0;
+    }
+
 }
 
 /* Large devices (desktops, 992px and up) */
 @media (min-width: 992px) {
     .techo-hero h1, .techo-hero h2 {
-        font-size:4rem; /*1rem = 16px*/
+        font-size: 3rem;
+        padding: 2rem 0;
     }
 
     h1 {
@@ -443,7 +482,8 @@ footer.inscripcion-bar .text-primary {
 /* Extra large devices (large desktops, 1200px and up) */
 @media (min-width: 1200px) {
     .techo-hero h1, .techo-hero h2 {
-        font-size:5rem; /*1rem = 16px*/
+        font-size: 4rem; /*1rem = 16px*/
+        padding: 3rem 0;
     }
 
     h1 {
@@ -459,7 +499,8 @@ footer.inscripcion-bar .text-primary {
 }
 
 
-.flex-container {
+
+/*.flex-container {
     display: flex;
     position: absolute;
     margin-top: 1.1em;
@@ -529,7 +570,6 @@ footer.inscripcion-bar .text-primary {
     }
 }
 
-/* Large devices (desktops, 992px and up) */
 @media (min-width: 992px) {
     .flex-container {
         margin-top: 5.5em;
@@ -569,4 +609,4 @@ footer.inscripcion-bar .text-primary {
     .flex-container > div {
         width: 32em;
     }
-  }
+  }*/

--- a/public/css/atlas.css
+++ b/public/css/atlas.css
@@ -311,6 +311,13 @@ a {
     font-weight: 700;
 }
 
+.estadisticas-publicas-label {
+    background-color: #00000040;
+    text-transform: uppercase;
+    font-size: larger;
+    font-weight: 600;
+}
+
 .techo-hero h2 {
     font-size: 36px;
     position: absolute;

--- a/public/css/atlas.css
+++ b/public/css/atlas.css
@@ -416,7 +416,8 @@ footer.inscripcion-bar .text-primary {
 /* Medium devices (tablets, 768px and up) The navbar toggle appears at this breakpoint */
 @media (min-width: 768px) {
     .techo-hero h1, .techo-hero h2 {
-        font-size:3.5rem; /*1rem = 16px*/
+        font-size:2.5rem; /*1rem = 16px*/
+        padding-bottom: 5rem;
     }
 
     h1 {
@@ -456,3 +457,116 @@ footer.inscripcion-bar .text-primary {
         padding-top: 0;
     }
 }
+
+
+.flex-container {
+    display: flex;
+    position: absolute;
+    margin-top: 1.1em;
+    opacity: 0.9;
+    background-color: lightgrey;
+    text-shadow: 0 0 16px #60676a
+}
+  
+.flex-container > div {
+    background-color: lightgrey;
+    width: 10em;
+    font-size: 0.4rem;
+    padding: 0.5em;
+    }
+
+.flex-container > div > h3{
+    font-size: 0.6rem;
+    }
+
+@media (min-width: 375px) {
+    .flex-container {
+        margin-top: 1.5em;
+    }
+    .flex-container > div {
+        width: 12em;
+    }
+    .flex-container > div > h3{
+        font-size: 0.6rem;
+    }
+}
+
+@media (min-width: 425px) {
+    .flex-container > div {
+        width: 11em;
+        font-size: 0.5rem;
+    }
+    .flex-container > div > h3{
+        font-size: 0.7rem;
+    }
+}
+
+@media (min-width: 768px) {
+    .flex-container {
+        margin-top: 4em;
+    }
+    .flex-container > div {
+        width: 12em;
+        font-size: 0.8rem;
+        padding: 0.2em;
+    }
+    .flex-container > div > h3{
+        font-size: 1.3rem;
+    }
+}
+
+@media (min-width: 768px) {
+    .flex-container {
+        margin-top: 4em;
+    }
+    .flex-container > div {
+        width: 12em;
+        font-size: 0.8rem;
+        padding: 0.2em;
+    }
+    .flex-container > div > h3{
+        font-size: 1.3rem;
+    }
+}
+
+/* Large devices (desktops, 992px and up) */
+@media (min-width: 992px) {
+    .flex-container {
+        margin-top: 5.5em;
+        font-size: 1rem;  
+    }
+    .flex-container > div {
+        width: 16em;
+    }
+    .flex-container > div > h3{
+        font-size: 2rem;
+    }
+}
+
+
+@media (min-width: 1200px) {
+    .flex-container > div {
+        width: 20em;
+        padding: 0.5em;
+    }
+  }
+
+@media (min-width: 1440px) {
+    .flex-container {
+        margin-top: 6em;
+        font-size: 1.4rem;  
+    }
+    .flex-container > div {
+        width: 23em;
+    }
+  }
+
+@media (min-width: 1900px) {
+    .flex-container {
+        margin-top: 8em;
+        font-size: 1.4rem;  
+    }
+    .flex-container > div {
+        width: 32em;
+    }
+  }

--- a/public/css/atlas.css
+++ b/public/css/atlas.css
@@ -273,7 +273,7 @@ a {
 }
 
 .techo-hero h1 {
-    font-size: 5vw;
+    font-size: 6vw;
     margin: auto;
     /*position: absolute;*/
     z-index: 1;
@@ -469,11 +469,6 @@ footer.inscripcion-bar .text-primary {
 
 /* Large devices (desktops, 992px and up) */
 @media (min-width: 992px) {
-    .techo-hero h1, .techo-hero h2 {
-        font-size: 3rem;
-        padding: 2rem 0;
-    }
-
     h1 {
         font-size:2rem; /*1rem = 16px*/
     }
@@ -481,11 +476,6 @@ footer.inscripcion-bar .text-primary {
 
 /* Extra large devices (large desktops, 1200px and up) */
 @media (min-width: 1200px) {
-    .techo-hero h1, .techo-hero h2 {
-        font-size: 4rem; /*1rem = 16px*/
-        padding: 3rem 0;
-    }
-
     h1 {
         font-size:3rem; /*1rem = 16px*/
     }

--- a/resources/js/atlas.js
+++ b/resources/js/atlas.js
@@ -21,6 +21,7 @@ import DataTable from './components/datatable/DataTable';
 import BtnMisActividades from './components/perfil/btnMisActividades';
 import TarjetaHorizontal from './components/perfil/tarjeta-horizontal';
 import CookiesBar from './components/cookies-bar';
+import EstadisticasPublicas from './components/estadisticas-publicas';
 
 
 import axios from 'axios';
@@ -57,6 +58,7 @@ Vue.component('datatable', DataTable);
 Vue.component('btn-mis-actividades', BtnMisActividades);
 Vue.component('tarjeta-horizontal', TarjetaHorizontal);
 Vue.component('cookies-bar', CookiesBar);
+Vue.component('estadisticas-publicas', EstadisticasPublicas);
 
 window.Event = new Vue();
 

--- a/resources/js/components/estadisticas-publicas.vue
+++ b/resources/js/components/estadisticas-publicas.vue
@@ -1,21 +1,24 @@
 <template>
-	<div class="estadisticas-publicas">
-			<div> 
-				<h3>  {{ voluntades_movilizadas }} </h3>  
-				<span>Voluntades Movilizadas</span>
-			</div>
-			
-			<div> 
-				<h3>  {{ personas_movilizadas.length }} </h3> 
-				<span>Personas Movilizadas</span>
-			</div>
-
-			<template v-for="actividadtotal in actividadestotales">
+	<div>
+		<div class="estadisticas-publicas-label" >En el {{ciclo}} llevamos</div>
+		<div class="estadisticas-publicas">
 				<div> 
-					<h3> {{ actividadtotal.cantidad }} </h3> 
-					<span> {{ actividadtotal.nombre }} </span>
+					<h3>  {{ voluntades_movilizadas }} </h3>  
+					<span>Voluntades Movilizadas</span>
 				</div>
-			</template>
+				
+				<div> 
+					<h3>  {{ personas_movilizadas.length }} </h3> 
+					<span>Personas Movilizadas</span>
+				</div>
+
+				<template v-for="actividadtotal in actividadestotales">
+					<div> 
+						<h3> {{ actividadtotal.cantidad }} </h3> 
+						<span> {{ actividadtotal.nombre }} </span>
+					</div>
+				</template>
+		</div>
 	</div>
 </template>
 
@@ -26,12 +29,14 @@ export default {
 			personas_movilizadas: 0,
 			voluntades_movilizadas: 0,
 			actividadestotales: 0,
+			ciclo: 0,
 		};
 	},
 	mounted () {
 		this.get_voluntades_movilizadas();
 		this.get_actividades();
 		this.get_personas_movilizadas();
+		this.ciclo = moment().format("YYYY");
 	},
 	methods: {
 		get_personas_movilizadas: function () {

--- a/resources/js/components/estadisticas-publicas.vue
+++ b/resources/js/components/estadisticas-publicas.vue
@@ -1,10 +1,19 @@
 <template>
-	<div id="estadisticas_publicas" class="flex-container">
-			<div> <h3>  {{ personas_movilizadas.length }} </h3> Personas Movilizadas </div>
-			<div> <h3>  {{ voluntades_movilizadas }} </h3>  Voluntades Movilizadas  </div>
+	<div class="estadisticas-publicas">
+			<div> 
+				<h3>  {{ voluntades_movilizadas }} </h3>  
+				<span>Voluntades Movilizadas</span>
+			</div>
+			
+			<div> 
+				<h3>  {{ personas_movilizadas.length }} </h3> 
+				<span>Personas Movilizadas</span>
+			</div>
+
 			<template v-for="actividadtotal in actividadestotales">
 				<div> 
-					<h3> {{ actividadtotal.cantidad }} </h3> {{ actividadtotal.nombre }} 
+					<h3> {{ actividadtotal.cantidad }} </h3> 
+					<span> {{ actividadtotal.nombre }} </span>
 				</div>
 			</template>
 	</div>

--- a/resources/js/components/estadisticas-publicas.vue
+++ b/resources/js/components/estadisticas-publicas.vue
@@ -1,0 +1,43 @@
+<template>
+	<div id="estadisticas_publicas" class="flex-container">
+			<div> <h3>  {{ personas_movilizadas.length }} </h3> Personas Movilizadas </div>
+			<div> <h3>  {{ voluntades_movilizadas }} </h3>  Voluntades Movilizadas  </div>
+			<template v-for="actividadtotal in actividadestotales">
+				<div> 
+					<h3> {{ actividadtotal.cantidad }} </h3> {{ actividadtotal.nombre }} 
+				</div>
+			</template>
+	</div>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			personas_movilizadas: 0,
+			voluntades_movilizadas: 0,
+			actividadestotales: 0,
+		};
+	},
+	mounted () {
+		this.get_voluntades_movilizadas();
+		this.get_actividades();
+		this.get_personas_movilizadas();
+	},
+	methods: {
+		get_personas_movilizadas: function () {
+			axios.get('/ajax/estadisticas/personas_movilizadas' )
+			.then(response => (this.personas_movilizadas = response.data))
+		},
+		get_voluntades_movilizadas: function () {
+			axios.get('/ajax/estadisticas/voluntades_movilizadas' )
+			.then(response => (this.voluntades_movilizadas = response.data))
+		},
+		get_actividades: function () {
+			axios.get('/ajax/estadisticas/actividades' )
+			.then(response => (this.actividadestotales = response.data))
+		},
+	}
+}
+
+</script>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -16,8 +16,11 @@
           <source srcset="{{ asset('/img/hero-mobile.jpg') }}" media="(max-width: 720px)">
           <img src="{{ asset('/img/hero.jpg') }}" alt="hero image">
         </picture>
-        <h1 class="text-uppercase">Transformemos esta realidad</h1>
-        <estadisticas-publicas>   </estadisticas-publicas>
+        <h1 class="text-uppercase mobile">Transformemos esta realidad</h1>
+        <div class="techo-hero-text" >
+            <h1 class="text-uppercase desktop">Transformemos esta realidad</h1>
+            <estadisticas-publicas>   </estadisticas-publicas>
+        </div>
     </div>
 
     

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -17,7 +17,11 @@
           <img src="{{ asset('/img/hero.jpg') }}" alt="hero image">
         </picture>
         <h1 class="text-uppercase">Transformemos esta realidad</h1>
+        <estadisticas-publicas>   </estadisticas-publicas>
     </div>
+
+    
+
 @endsection
 
 @section('main_content')

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -19,7 +19,9 @@
         <h1 class="text-uppercase mobile">Transformemos esta realidad</h1>
         <div class="techo-hero-text" >
             <h1 class="text-uppercase desktop">Transformemos esta realidad</h1>
-            <estadisticas-publicas>   </estadisticas-publicas>
+            @if(config('app.estadisticas'))
+            <estadisticas-publicas></estadisticas-publicas>
+            @endif
         </div>
     </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,11 @@ Route::prefix('ajax')->group(function () {
     Route::get('actividades/{id}', 'ajax\ActividadesController@show');
 
     Route::get('auditorias/{tabla}/{id}', 'ajax\AuditoriasController@show');
+
+    Route::get('estadisticas/voluntades_movilizadas', 'EstadisticasController@voluntades_movilizadas');
+    Route::get('estadisticas/actividades', 'EstadisticasController@actividades');
+    Route::get('estadisticas/personas_movilizadas', 'EstadisticasController@personas_movilizadas');
+
 });
 //Fin Ajax calls
 


### PR DESCRIPTION
## Descripción
Se agrego al home las estadísticas generales de movilización de la plataforma, resolves #436 

La visualización es responsive para los diferentes dispositivos, va print para ordenador
![image](https://user-images.githubusercontent.com/11001346/67293835-5db95700-f4bb-11e9-8a81-3e46168b0811.png)


## ¿Cómo testeaste?
Entrar al sitio por diferentes dispositivos y ver que la funcionalidad se vea correctamente, dentro del espacio de la foto y con todos los datos visibles

## Checklist:

- [X] Revisé mi código
- [X] Funcionalidad Responsive
- [X] Seleccion de queries más rápidas
