### PR TITLE
Incorpora 344 cerrar punto encuentro

### DIFF
--- a/app/Http/Controllers/InscripcionesController.php
+++ b/app/Http/Controllers/InscripcionesController.php
@@ -48,6 +48,8 @@ class InscripcionesController extends BaseController
         $punto_encuentro = PuntoEncuentro::find($request->input('punto_encuentro'));
         $punto_encuentro->load('pais','provincia','localidad');
         $persona = Auth::user();
+        if ($punto_encuentro->estado)
+        {
         if (($request->has('aceptar_terminos') && $request->aceptar_terminos == 1)) {
             $inscripcion = Inscripcion::where([['idActividad', $id], ['idPersona', Auth::user()->idPersona]])->get()->first();
             if (!$inscripcion) {
@@ -95,6 +97,8 @@ class InscripcionesController extends BaseController
             ->with('actividad', $actividad)
             ->with('punto_encuentro', $punto_encuentro)
             ->with('tipo', $actividad->tipo);
+        }
+        return response('El punto de encuentro se encuentra cerrado', 500);
     }
 
     /**

--- a/app/Http/Controllers/backoffice/ActividadesController.php
+++ b/app/Http/Controllers/backoffice/ActividadesController.php
@@ -402,6 +402,7 @@ class ActividadesController extends Controller
         $p->idPais = $punto['idPais'];
         $p->idProvincia = $punto['idProvincia'];
         $p->idPersona = $punto['responsable']['idPersona'];
+        $p->estado =  ($punto['estado']) ? 1 : 0;
         $p->save();
         return $punto;
     }
@@ -414,6 +415,7 @@ class ActividadesController extends Controller
         $punto->idPais = $editado['idPais'];
         $punto->idProvincia = $editado['idProvincia'];
         $punto->idPersona = $editado['responsable']['idPersona'];
+        $punto->estado = $editado['estado'];
         $punto->save();
         return $punto;
     }

--- a/app/Http/Controllers/backoffice/ActividadesController.php
+++ b/app/Http/Controllers/backoffice/ActividadesController.php
@@ -402,7 +402,7 @@ class ActividadesController extends Controller
         $p->idPais = $punto['idPais'];
         $p->idProvincia = $punto['idProvincia'];
         $p->idPersona = $punto['responsable']['idPersona'];
-        $p->estado =  ($punto['estado']) ? 1 : 0;
+        $p->estado = $punto['estado'];
         $p->save();
         return $punto;
     }

--- a/app/Http/Resources/PuntoEncuentroResource.php
+++ b/app/Http/Resources/PuntoEncuentroResource.php
@@ -22,6 +22,7 @@ class PuntoEncuentroResource extends Resource
             'localidad' => $this->localidad,
             'responsable' => new PersonaResource($this->responsable),
             'borrable' => true,
+            'estado' => $this->estado,
         ];
     }
 }

--- a/database/factories/PuntoEncuentroFactory.php
+++ b/database/factories/PuntoEncuentroFactory.php
@@ -8,9 +8,15 @@ $factory->define(App\PuntoEncuentro::class, function (Faker $faker) {
     return [
       'punto'=> $faker->name,
       'horario' => '00:00:00',
+      'estado' => 1,
       'idPersona' => factory(App\Persona::class)->create(),
       'idPais' => factory(App\Pais::class)->create(),
       'idProvincia' => factory(App\Provincia::class)->create(),
       'idLocalidad' => factory(App\Localidad::class)->create()
     ];
+
 });
+
+$factory->state(App\PuntoEncuentro::class, 'cerrado', [
+    'estado' => 0,
+]);

--- a/database/migrations/2019_10_24_055702_incluye_campo_estado_en_puntoencuentro.php
+++ b/database/migrations/2019_10_24_055702_incluye_campo_estado_en_puntoencuentro.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class IncluyeCampoEstadoEnPuntoencuentro extends Migration
+{
+    /**
+    * Run the migrations.
+    *
+    * @return void
+    */
+    public function up()
+    {
+        Schema::table('PuntoEncuentro', function (Blueprint $table) {
+            $table->integer('estado')->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('PuntoEncuentro', function (Blueprint $table) {
+                $table->dropColumn('estado');
+        });
+    }
+}

--- a/resources/js/components/backoffice/actividades/actividades-show.vue
+++ b/resources/js/components/backoffice/actividades/actividades-show.vue
@@ -524,6 +524,7 @@
             Event.$on('guardar', this.guardar);
             Event.$on('borrar-punto', this.borrarPunto);
             Event.$on('editar-punto', this.editarPunto);
+            Event.$on('cambiar-estado-punto', this.cambiarEstadoPunto);
             Event.$on('eliminar', this.eliminar);
             Event.$on('clonar', this.clonar);
         },
@@ -750,6 +751,10 @@
             borrarPunto: function (obj) {
                 this.dataActividad.puntosEncuentroBorrados.push(obj.obj);
                 this.dataActividad.puntos_encuentro.splice(obj.index, 1);
+            },
+            cambiarEstadoPunto: function (obj) {
+                this.dataActividad.puntosEncuentroEditados.push(obj.obj);
+
             },
             editarPunto: function (obj) {
                 //mostrar form

--- a/resources/js/components/backoffice/actividades/punto-encuentro.vue
+++ b/resources/js/components/backoffice/actividades/punto-encuentro.vue
@@ -119,6 +119,7 @@
                 <th scope="col">Lugar</th>
                 <th scope="col">Horario</th>
                 <th scope="col">Responsable</th>
+                <th scope="col">Estado</th>
                 <th scope="col"><span v-show="!readonly">Acciones</span></th>
             </thead>
             <tbody>
@@ -135,6 +136,9 @@
                     </td>
                     <td>
                         <p>{{ punto.responsable.nombres }} {{ punto.responsable.apellidoPaterno}}</p>
+                    </td>
+                    <td>
+                        <v-switch theme="bootstrap" color="primary" v-bind:disabled="readonly" @input="cambiarEstadoPunto(punto.idPuntoEncuentro)" v-model="punto.estado"> </v-switch>
                     </td>
                     <td>
                         <div class="form-group" v-if="!readonly">
@@ -372,6 +376,10 @@
             editar: function (id) {
                 let data = this.findObjectByKey(this.puntosEncuentro, 'idPuntoEncuentro', id);
                 Event.$emit('editar-punto', data);
+            },
+            cambiarEstadoPunto: function (id) {
+                let data = this.findObjectByKey(this.puntosEncuentro, 'idPuntoEncuentro', id);
+                Event.$emit('cambiar-estado-punto', data);
             },
             getProvincias() {
                 if (this.paisSeleccionado !== null && this.paisSeleccionado.id !== undefined) {

--- a/resources/js/components/inscripcion.vue
+++ b/resources/js/components/inscripcion.vue
@@ -24,7 +24,7 @@
                     method="POST"
                     v-on:submit="validateForm"
             >
-              <div class="row" v-for="(item, index) in actividad.puntosEncuentro">
+              <div class="row" v-for="(item, index) in puntosActivos">
                   <div class="col-md-12">
                       <input type="radio" name="punto_encuentro" v-bind:value="item.idPuntoEncuentro"  v-bind:checked="index == 0 ? 'checked' : ''" style="margin: 0px 6px;">
                     {{item.punto}}, 
@@ -124,6 +124,11 @@
           }
         },
         computed: {
+            puntosActivos: function () {
+                return this.actividad.puntosEncuentro.filter(function (punto) {
+                    return punto.estado
+                })
+            },
             esConstruccion() {
                 return this.actividad.tipo ? this.actividad.tipo.flujo == "CONSTRUCCION" : false;
             },

--- a/resources/js/components/registro.vue
+++ b/resources/js/components/registro.vue
@@ -195,7 +195,7 @@
             <div class="row h-100 justify-content-center align-items-center">
                 <div class="col-md-5">
                     <div class="form-group">
-                        <label>País de residencia</label>
+                        <label>País de residencia *</label>
                         <select id="pais" v-model="user.pais" class="form-control">
                             <option v-for="pais in paises" v-bind:value="pais.id">{{pais.nombre}}</option>
                         </select>
@@ -392,7 +392,8 @@
             this.validar_data('pais') 
             this.traer_provincias() 
         },
-        'user.provincia': function() { this.traer_localidades() }
+        'user.provincia': function() { this.traer_localidades() },
+        'user.privacidad': function() { this.validar_data('privacidad')}
       },
       methods: {
         registro_facebook: function() {

--- a/resources/views/actividades/show.blade.php
+++ b/resources/views/actividades/show.blade.php
@@ -72,9 +72,10 @@
 			</div>
 		</div>
 		@foreach($actividad->puntosEncuentro as $puntoEncuentro)
-			<div class="row">
+            @if($puntoEncuentro->estado)
+		      <div class="row">
                 <div class="col-md-4">
-				{{$puntoEncuentro->punto}}
+				    {{$puntoEncuentro->punto}}
                 </div>
                 <div class="col-md-4">
                     @php
@@ -87,7 +88,8 @@
                 <div class="col-md-4">
                     <strong>Referente:</strong> {{isset($puntoEncuentro->responsable) ? $puntoEncuentro->responsable->nombreCompleto : "No definido"}}
                 </div>
-			</div>
+		      </div>
+            @endif
 		@endforeach
 @endsection
 

--- a/tests/Feature/ActividadesTest.php
+++ b/tests/Feature/ActividadesTest.php
@@ -38,10 +38,10 @@ class ActividadesTest extends TestCase
 
         $punto = factory('App\PuntoEncuentro')->make();
         $punto->nuevo = true;
+        $punto->estado = true;
         $punto->responsable = $punto->idPersona;
 
         $actividad_t['puntos_encuentro'] = [ $punto->toArray() ];
-
         $this->actingAs($persona)
         	->post('/admin/actividades/crear', $actividad_t)
         	->assertSeeText('Actividad creada correctamente')

--- a/tests/Feature/InscripcionesTest.php
+++ b/tests/Feature/InscripcionesTest.php
@@ -130,9 +130,8 @@ class InscripcionesTest extends TestCase
         $actividad = app(ActividadFactory::class)
             ->create();
 
-        $punto_encuentro = factory('App\PuntoEncuentro')->create([
+        $punto_encuentro = factory('App\PuntoEncuentro')->states('cerrado')->create([
                 'idActividad' => $actividad->idActividad,
-                'estado' => 0
             ]);
 
         $datos = [

--- a/tests/Feature/InscripcionesTest.php
+++ b/tests/Feature/InscripcionesTest.php
@@ -119,6 +119,37 @@ class InscripcionesTest extends TestCase
 
     }
 
+    /** @test **/
+    public function usuario_no_puede_ver_ni_inscribirse_a_punto_cerrado()
+    {
+        $this->withoutExceptionHandling();
+        $this->seed('PermisosSeeder');
+
+        $usuario = factory('App\Persona')->create();
+
+        $actividad = app(ActividadFactory::class)
+            ->create();
+
+        $punto_encuentro = factory('App\PuntoEncuentro')->create([
+                'idActividad' => $actividad->idActividad,
+                'estado' => 0
+            ]);
+
+        $datos = [
+            'punto_encuentro' => $actividad->puntosEncuentro->first()->idPuntoEncuentro, 
+            'aceptar_terminos' => 1 
+        ];
+
+        $this->actingAs($usuario)
+            ->get('/actividades/' . $actividad->idActividad)
+            ->assertDontSee($actividad->puntosEncuentro->first()->punto);
+
+        $this->actingAs($usuario)
+            ->post('/inscripciones/actividad/' . $actividad->idActividad . '/gracias',$datos)
+            ->assertStatus(500);   
+    }
+
+
     /** @test */
     public function usuario_se_puede_desinscribir()
     {


### PR DESCRIPTION
**Resolve #344** para cerrar puntos de encuentro durante una actividad abierta
Desde el admin se puede cerrar editando la actividad y cambiando el switch, asi
![image](https://user-images.githubusercontent.com/11001346/67500003-65fac900-f658-11e9-8616-7eda447a1c6f.png)
y luego el mismo tampoco se ve desde el usuario que se quiere inscribir al mismo

**Resolve #181** Ahora este error no se da mas y saca el cartel de error automáticamente


## ¿Cómo testeaste?
Cree un test para verificar que el usuario no pueda ver ni anotarse en un punto cerrado, también lo testee visualmente cerrando un punto e intentando por fuerza bruta.

## Describí que hiciste para verificar los cambios.
- Como admin cree una actividad
- agrego puntos de encuentro activos
- guardo y veo que puedo anotarme
- cierro uno y veo que no aparece

## Checklist:
- [X] Revisé mi código
- [X] Agregué tests que muestran que mi arreglo está bien o que mi funcionalidad anda.
