### PR TITLE
Corrije 503 - Error al exportar inscriptos

### DIFF
--- a/app/Http/Controllers/backoffice/ReportController.php
+++ b/app/Http/Controllers/backoffice/ReportController.php
@@ -33,7 +33,7 @@ class ReportController extends Controller
     {
         $filtros['idActividad'] = $id;
 
-        if(!empty($request->filter)){
+        if($request->filter){
             $filtros['HotFilter'] = $request->filter;
             unset($filtros['filter']);
         }

--- a/resources/js/components/backoffice/datatable/InscripcionesTable.vue
+++ b/resources/js/components/backoffice/datatable/InscripcionesTable.vue
@@ -363,7 +363,7 @@ export default {
       Vue.nextTick( () => this.$refs.inscripcionesVuetable.refresh() )
     },
     'filter-reset-inscripciones' () {
-      this.moreParams.filter = null;
+      this.moreParams.filter = [];
       this.$refs.inscripcionesVuetable.resetData();
       Vue.nextTick( () => this.$refs.inscripcionesVuetable.refresh() )
     }


### PR DESCRIPTION
## Descripción
Resolves #503 que se daba despues de filtrar inscriptos y borrar el filtro. La lógica no contemplaba bien esta posibilidad, modifique la misma para que siga exportando bien utilizando filtro así como descargando todos, filtrando antes o no.

## ¿Cómo testeaste?
- Entro a actividad
- descargo inscriptos ok
- filtro inscriptos
- descargo inscriptos filtrados ok
- borro filtro
- descargo inscriptos ok

- [x] Revisé mi código