### PR TITLE
Agrega exportador de evaluaciones

### DIFF
--- a/app/Exports/EvaluacionesGeneralesExport.php
+++ b/app/Exports/EvaluacionesGeneralesExport.php
@@ -1,0 +1,63 @@
+<?php
+namespace App\Exports;
+
+use App\EvaluacionPersona;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+
+class EvaluacionesGeneralesExport implements FromCollection, WithHeadings, ShouldAutoSize
+{
+    protected $actividad;
+
+
+    public function __construct($request)
+    {
+        $this->request = $request;
+    }
+
+    public function collection()
+    {
+        $año = ($this->request->filled('año'))?$this->request->año:Carbon::now()->format('Y');
+        $pais = ($this->request->filled('pais'))?$this->request->pais:null;
+        $oficina = ($this->request->filled('oficina'))?$this->request->oficina:null;
+
+        $consulta = \App\EvaluacionPersona::join('Persona', 'Persona.idPersona', '=', 'EvaluacionPersona.idEvaluado')
+            ->join('Actividad', 'Actividad.idActividad', '=', 'EvaluacionPersona.idActividad')
+            ->join('Inscripcion', function($join){
+                $join->on('Inscripcion.idPersona', '=', 'Persona.idPersona');
+                $join->on('Inscripcion.IdActividad', '=', 'Actividad.idActividad');
+            })
+            ->join('atl_oficinas', 'Actividad.idOficina', '=', 'atl_oficinas.id')
+            ->select('Persona.nombres', 'Persona.apellidoPaterno', 'Persona.dni', 'Persona.mail', 'Actividad.nombreActividad', 'Inscripcion.rol', 
+                DB::raw(' atl_oficinas.nombre, AVG(EvaluacionPersona.puntajeSocial) as puntajeSocial'), 
+                DB::raw('AVG(EvaluacionPersona.puntajeTecnico) as puntajeTecnico'))
+            ->groupBy('Persona.nombres', 'Persona.apellidoPaterno', 'Persona.dni', 'Persona.mail', 'Actividad.nombreActividad', 
+                'atl_oficinas.nombre', 'Inscripcion.rol')
+            ->whereYear('Inscripcion.created_at', $año);
+
+
+        if($pais) $consulta->where('Actividad.idPais', $pais);
+        if($oficina) $consulta->where('Actividad.idOficina', $oficina);
+
+        return $consulta->get();
+    }
+
+    public function headings(): array
+    {
+        return [
+            'Nombre',
+            'Apellido',
+            'DNI',
+            'Email',
+            'Nombre actividad',
+            'Rol',
+            'Oficina',
+            'Puntaje Social',
+            'Puntaje Técnico',
+        ];
+    }
+
+}

--- a/app/Http/Controllers/backoffice/EstadisticasController.php
+++ b/app/Http/Controllers/backoffice/EstadisticasController.php
@@ -74,6 +74,32 @@ class EstadisticasController extends Controller
         return $respuesta;
     }
 
+    public function grafico_evaluaciones(Request $request)
+    {
+        $año = ($request->filled('año'))?$request->año:Carbon::now()->format('Y');
+        $pais = ($request->filled('pais'))?$request->pais:null;
+        $oficina = ($request->filled('oficina'))?$request->oficina:null;
+
+        $consulta = \App\EvaluacionPersona::join('Actividad', 'Actividad.idActividad', '=', DB::raw('EvaluacionPersona.idActividad'))
+            ->select(DB::raw('MONTH(Actividad.fechaCreacion) as mes, AVG(EvaluacionPersona.puntajeSocial) as puntajeSocial, AVG(EvaluacionPersona.puntajeTecnico) as puntajeTecnico'))
+            ->groupBy('mes')
+            ->whereYear('Actividad.fechaCreacion', $año);
+
+        if($pais) $consulta->where('Actividad.idPais', $pais);
+        if($oficina) $consulta->where('Actividad.idOficina', $oficina);
+        
+        $evaluaciones = $consulta->get();
+
+        $respuesta = [];
+        foreach ($evaluaciones as $e) {
+            $respuesta['meses'][] = $e->mes;
+            $respuesta['puntajeSocial'][] = $e->puntajeSocial;
+            $respuesta['puntajeTecnico'][] = $e->puntajeTecnico;
+        }
+
+        return $respuesta;
+    }
+
     public function inscripciones_por_actividad(Request $request)
     {
         

--- a/app/Http/Controllers/backoffice/ReportController.php
+++ b/app/Http/Controllers/backoffice/ReportController.php
@@ -7,6 +7,7 @@ use App\Exports\ActividadesExport;
 use App\Exports\EvaluacionesActividadExport;
 use App\Exports\EvaluacionesPersonasExport;
 use App\Exports\EvaluacionesUsuarioExport;
+use App\Exports\EvaluacionesGeneralesExport;
 use App\Exports\InscripcionesUsuarioExport;
 use App\Exports\InscripcionesExport;
 use App\Exports\InscripcionesGeneralExport;
@@ -60,6 +61,12 @@ class ReportController extends Controller
         return Excel::download($inscripciones, 'inscripciones.xlsx');
     }
 
+    public function exportarEvaluacionesGenerales(Request $request)
+    {
+        $evaluaciones = new EvaluacionesGeneralesExport($request);
+        return Excel::download($evaluaciones, 'evaluaciones.xlsx');
+    }
+    
     public function exportarEvaluacionesPersonas($id)
     {
         $actividad = Actividad::find($id);

--- a/routes/web.php
+++ b/routes/web.php
@@ -232,6 +232,7 @@ Route::prefix('/admin')->middleware(['verified', 'auth', 'can:accesoBackoffice']
     Route::get('/ajax/paises', 'ajax\PaisesController@paises');
     Route::get('/ajax/estadisticas/grafico-inscripciones', 'backoffice\EstadisticasController@grafico_inscripciones');
     Route::get('/ajax/estadisticas/grafico-actividades', 'backoffice\EstadisticasController@grafico_actividades');
+    Route::get('/ajax/estadisticas/grafico-evaluaciones', 'backoffice\EstadisticasController@grafico_evaluaciones');
     Route::get('/ajax/estadisticas/inscripciones-por-actividad', 'backoffice\EstadisticasController@inscripciones_por_actividad');
     Route::get('/ajax/estadisticas/evaluaciones-por-actividad', 'backoffice\EstadisticasController@evaluaciones_por_actividad');
     Route::get('/ajax/estadisticas/coordinadores', 'backoffice\EstadisticasController@coordinadores');
@@ -240,6 +241,8 @@ Route::prefix('/admin')->middleware(['verified', 'auth', 'can:accesoBackoffice']
     Route::get('/ajax/estadisticas/evaluaciones-tecnicas', 'backoffice\EstadisticasController@evaluaciones_tecnicas');
 
     Route::get('/ajax/estadisticas/inscripciones/exportar', 'backoffice\ReportController@ExportarInscripciones');
+    Route::get('/ajax/estadisticas/evaluaciones/exportar', 'backoffice\ReportController@exportarEvaluacionesGenerales');
+    
     
 });
 


### PR DESCRIPTION
## Descripción
Resolves #507 agregando un bot[on de exportar y un grafico por mes de evaluaciones (social y tecnica), habilado el filtro para acceder a información especifica

se accede mediante Estadisticas > Generales > Evaluaciones
![image](https://user-images.githubusercontent.com/11001346/67970684-26992300-fbea-11e9-97fc-c0103af72166.png)

## ¿Cómo testeaste?
- Entro como Admin
- Estadísticas - Generales - Evaluaciones
- Bajo listado completo
- Bajo listado por Oficina
- Bajo listado con fecha
- Bajo listado de inscripciones
- Bajo listado inscriptos por fecha
- Veo que nada se mueve el front al momento de ir a otra sección de la página

## Checklist:

- [X] Revisé mi código
- [X] Hice tests manuales de descarga de archivos
- [X] Listo para probar en Sandbox
